### PR TITLE
Upgrade project to GitHub standards.

### DIFF
--- a/Core/azure-pipelines.yml
+++ b/Core/azure-pipelines.yml
@@ -12,6 +12,18 @@ trigger:
     - README.md
     - License.md
 
+pr:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - Core/*
+    exclude:
+    - Steps/Core/*
+    - README.md
+    - License.md
+
 pool:
   vmImage: 'windows-latest'
 
@@ -39,7 +51,7 @@ variables:
 - name: 'sonarCloudProjectName'
   value: 'Pipelines.Core'
 
-- name: 'primarySourceBranch'
+- name: 'sonarCloudSourceBranch'
   value: 'refs/heads/master'
   
 steps:

--- a/Steps/Core/LICENSE
+++ b/Steps/Core/LICENSE
@@ -1,5 +1,7 @@
 MIT License
 
+Copyright (c) 2019-2021 Chris Trout
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/Steps/Core/MyTrout.Pipelines.Steps.sln
+++ b/Steps/Core/MyTrout.Pipelines.Steps.sln
@@ -6,8 +6,8 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7C30B959-8AB9-4868-8A71-6BD4C026A38F}"
 	ProjectSection(SolutionItems) = preProject
 		azure-pipelines.yml = azure-pipelines.yml
-		changelog.md = changelog.md
-		License.md = License.md
+		CHANGELOG.md = CHANGELOG.md
+		LICENSE = LICENSE
 		README.md = README.md
 		stylecop.json = stylecop.json
 	EndProjectSection

--- a/Steps/Core/README.md
+++ b/Steps/Core/README.md
@@ -2,7 +2,13 @@
 
 MyTrout.Pipelines.Steps provides step base classes and pipeline Stream manipulation implementations MyTrout.Pipelines.
 
-MyTrout.Pipelines.Steps targets [.NET Standard 2.1](https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-implementation-support)
+[![Build Status](https://dev.azure.com/mytrout/Pipelines/_apis/build/status/mytrout.Pipelines.Steps.Core?branchName=master)](https://dev.azure.com/mytrout/Pipelines/_build/latest?definitionId=14&branchName=master)
+[![nuget](https://img.shields.io/nuget/v/MyTrout.Pipelines.Steps.svg)](https://www.nuget.org/packages/MyTrout.Pipelines.Steps/)
+[![GitHub stars](https://img.shields.io/github/stars/mytrout/Pipelines.svg)](https://github.com/stefanprodan/AspNetCoreRateLimit/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/mytrout/Pipelines.svg)](https://github.com/stefanprodan/AspNetCoreRateLimit/network)
+[![License: MIT](https://img.shields.io/github/license/mytrout/Pipelines.svg)](https://licenses.nuget.org/MIT)
+
+MyTrout.Pipelines.Steps targets [.NET 5.0](https://dotnet.microsoft.com/download/dotnet/5.0)
 
 If three steps named M1, M2, and M3 were added to the Pipeline, here is the execution path for the code.
 
@@ -12,7 +18,7 @@ For more details on Pipelines, see [Pipelines.Core](../Core/README.md)
 
 For more details on Pipelines.Hosting, see [Pipelines.Hosting](../../Hosting/README.md)
 
-For a list of available steps, see [Available Steps](../Steps/README.md)
+For a list of available steps, see [Available Steps](../README.md)
 
 # Installing via NuGet
 
@@ -20,14 +26,14 @@ For a list of available steps, see [Available Steps](../Steps/README.md)
 
 # Software dependencies
     1. Microsoft.CSharp 4.7.0 (required because of dynamic keyword usage for multi-context steps)
-    2. Microsoft.Extensions.Configuration.Abstractions 3.1.5
-    3. Microsoft.Extensions.Logging.Abstractions 3.1.5
-    4. MyTrout.Pipelines 1.1.*
+    2. Microsoft.Extensions.Configuration.Abstractions 5.0.0
+    3. Microsoft.Extensions.Logging.Abstractions 5.0.0
+    4. MyTrout.Pipelines 2.0.7 minimum, 2.*.* is acceptable.
 
 All software dependencies listed above use the [MIT License](https://licenses.nuget.org/MIT).
 
 # How do I write a "simple" Step?
-At a minimum, each step should implement the [IPipelineRequest](../Core/src/IPipelineRequest.cs) interface which implements [IAsyncDisposable](https://docs.microsoft.com/en-us/dotnet/api/system.iasyncdisposable?view=dotnet-plat-ext-3.1). 
+At a minimum, each step should implement the [IPipelineRequest](../../Core/src/IPipelineRequest.cs) interface.
 
 Review the [NoOpStep](../Core/src/Steps/NoOpStep.cs) for the minimum viable implementation.
 

--- a/Steps/Core/azure-pipelines.yml
+++ b/Steps/Core/azure-pipelines.yml
@@ -11,6 +11,17 @@ trigger:
     - README.md
     - License.md
 
+pr:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - Steps/Core/*
+    exclude:
+    - README.md
+    - License.md
+
 pool:
   vmImage: 'windows-latest'
 
@@ -24,20 +35,10 @@ variables:
 - name: 'buildConfiguration'
   value: 'Release'
 
-- name: 'major'
-  value: 2
-
-- name: 'minor'
-  value: 0
-
-- name: 'patch'
-  value: 0
+- group: 'MyTrout.Pipelines.Steps.Core.Version'
 
 - name: 'buildId'
   value: $[counter(variables['patch'], 0)]
-
-- name: 'suffix'
-  value: ''
 
 - group: 'Pipelines Artifacts Feed'
 - group: 'SonarQube Analysis'
@@ -48,7 +49,7 @@ variables:
 - name: 'sonarCloudProjectName'
   value: 'Pipelines.Steps.Core'
 
-- name: 'primarySourceBranch'
+- name: 'sonarCloudSourceBranch'
   value: 'refs/heads/master'
   
 steps:

--- a/Steps/Core/changelog.md
+++ b/Steps/Core/changelog.md
@@ -1,3 +1,13 @@
+# MyTrout.Pipelines.Steps.Core Change Log
+
+## 2.0.6
+ - Upgrade to .NET 5.0
+ - Change the project and repository urls from dev.azure.com/mytrout to github.com.
+ - Move versioning out of the azure-pipelines.yml and into Azure DevOps.
+ - Remove deprecated Microsoft.CodeAnalysis.NetAnalyzers library.
+ - Remove deprecated Microsoft.CodeAnalysis.FxCopAnalyzers library.
+ - Use primarySourceBranch variable for builds to allow SonarQube analysis to be performed on feature branches.
+
 ## 1.0.1
 - Limit MyTrout.Pipelines versions to >= 1.1 and < 2.0 in the nuget package.
 
@@ -11,7 +21,7 @@
 - Move StreamExtensions to the MyTrout.Pipelines.Steps.Core assembly.
 
 ## 0.27.0-beta
-- Refactor PIpelineContext and Parameter Validation Extension methods into two different classes.
+- Refactor PipelineContext and Parameter Validation Extension methods into two different classes.
 
 ## 0.26.3-beta
 - Add AssertParameterIsNotWhiteSpace to the Parameter Validation Extensions.

--- a/Steps/Core/src/MyTrout.Pipelines.Steps.csproj
+++ b/Steps/Core/src/MyTrout.Pipelines.Steps.csproj
@@ -11,8 +11,8 @@
     <AssemblyVersion>0.5.0.0</AssemblyVersion>
     <FileVersion>0.5.0.0</FileVersion>
     <Description>Provides step base classes and pipeline Stream manipulation implementations MyTrout.Pipelines.</Description>
-    <PackageProjectUrl>https://dev.azure.com/mytrout/Pipelines</PackageProjectUrl>
-    <RepositoryUrl>https://dev.azure.com/mytrout/Pipelines</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/mytrout/Pipelines/tree/master/Steps/Core</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/mytrout/Pipelines.git</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
@@ -35,27 +35,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.5" />
-    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.8.55">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.6.13">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="MyTrout.Pipelines" Version="[1.1,2)" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.8.0.18411">
+    <PackageReference Include="MyTrout.Pipelines" Version="[2.0.7,3)" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.15.0.24505">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Steps/Core/src/PipelineContextValidationExtensions.cs
+++ b/Steps/Core/src/PipelineContextValidationExtensions.cs
@@ -59,7 +59,7 @@ namespace MyTrout.Pipelines.Steps
             source.AssertParameterIsNotNull(nameof(source));
             key.AssertParameterIsNotWhiteSpace(nameof(key));
 
-            if (!source.Items.TryGetValue(key, out object workingItem))
+            if (!source.Items.TryGetValue(key, out object? workingItem))
             {
                 throw new InvalidOperationException(Resources.NO_KEY_IN_CONTEXT(CultureInfo.CurrentCulture, key));
             }


### PR DESCRIPTION
Change License.md to LICENSE.
Change changelog.md to CHANGELOG.md.
Add v2.0.6 changes to Change Log.
Correct potential null reference exception in  PipelineContextValidationExtensions.cs 
Update azure-pipelines.yml to use sonarCloudSourceBranch instead of primarySourceBranch for both Core/* and Steps/Core/*