### PR TITLE
Feature/add execution timings enumeration

### DIFF
--- a/Steps/Core/azure-pipelines.yml
+++ b/Steps/Core/azure-pipelines.yml
@@ -43,6 +43,9 @@ variables:
 - group: 'Pipelines Artifacts Feed'
 - group: 'SonarQube Analysis'
 
+- name: 'artifactPublishEnabled'
+  value: 'YES'
+
 - name: 'sonarCloudProjectKey'
   value: 'Pipelines.Steps.Core'
 
@@ -51,6 +54,6 @@ variables:
 
 - name: 'sonarCloudSourceBranch'
   value: 'refs/heads/master'
-  
+
 steps:
   - template: ../../nuget-build-template.yml

--- a/Steps/Core/changelog.md
+++ b/Steps/Core/changelog.md
@@ -2,6 +2,7 @@
 
 ## 2.0.7
 - Add ExtensionTimings to allow steps to configure when the step will be executed.
+- Add artifactPublishEnabled = 'YES' to the azure-pipelines.yml
 
 ## 2.0.6
  - Upgrade to .NET 5.0

--- a/Steps/Core/changelog.md
+++ b/Steps/Core/changelog.md
@@ -1,5 +1,8 @@
 # MyTrout.Pipelines.Steps.Core Change Log
 
+## 2.0.7
+- Add ExtensionTimings to allow steps to configure when the step will be executed.
+
 ## 2.0.6
  - Upgrade to .NET 5.0
  - Change the project and repository urls from dev.azure.com/mytrout to github.com.

--- a/Steps/Core/src/ExecutionTimings.cs
+++ b/Steps/Core/src/ExecutionTimings.cs
@@ -1,0 +1,45 @@
+﻿// <copyright file="ExecutionTimings.cs" company="Chris Trout">
+// MIT License
+//
+// Copyright(c) 2019-2020 Chris Trout
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+namespace MyTrout.Pipelines.Steps
+{
+    using System;
+
+    /// <summary>
+    /// Provides options for when the execution of the step will happen.
+    /// </summary>
+    [Flags]
+    public enum ExecutionTimings
+    {
+        /// <summary>
+        /// Executes the step before later-configured steps are called.
+        /// </summary>
+        Before = 1,
+
+        /// <summary>
+        /// Executes the step after later-configured steps are called.
+        /// </summary>
+        After = 2
+    }
+}

--- a/Steps/IO/Files/README.md
+++ b/Steps/IO/Files/README.md
@@ -28,7 +28,7 @@ MyTrout.Pipelines.Steps.IO.Files targets [.NET 5.0](https://dotnet.microsoft.com
 
 ## Software dependencies
 
-    1. MyTrout.Pipelines.Steps 1.0.*
+    1. MyTrout.Pipelines.Steps 2.0.7 minimum, 2.*.* is acceptable.
 
 All software dependencies listed above use the [MIT License](https://licenses.nuget.org/MIT).
 

--- a/Steps/IO/Files/changelog.md
+++ b/Steps/IO/Files/changelog.md
@@ -5,6 +5,7 @@
 - Upgrade all analyzers and remove deprecated analyzers.
 - Add the ExecutionTimings to DeleteFileOptions, MoveFileOptions, and WriteStreamToFileSystemOptions.
 - Add the ability to execute on the request or response side for DeleteFileStep, MoveFileStep, and WriteStreamToFileSystemStep.
+- Correct analyzer warnings.
 
 ## 2.0.0
 - Upgrade to .NET 5.0

--- a/Steps/IO/Files/changelog.md
+++ b/Steps/IO/Files/changelog.md
@@ -1,7 +1,14 @@
 # MyTrout.Pipelines.Steps.IO.Files Change Log
 
+## 2.1.0
+- Upgrade to MyTrout.Pipelines.Steps v2.0.7
+- Upgrade all analyzers and remove deprecated analyzers.
+- Add the ExecutionTimings to DeleteFileOptions, MoveFileOptions, and WriteStreamToFileSystemOptions.
+- Add the ability to execute on the request or response side for DeleteFileStep, MoveFileStep, and WriteStreamToFileSystemStep.
+
 ## 2.0.0
 - Upgrade to .NET 5.0
+- Upgrade to MyTrout.Pipelines.Steps v2.0.0.
 - Add nuget, build, and sonarqube badges to README.md.
 - Add nullable requirements and C# Language Version 9.0 to the project.
 - Update azure-pipelines.xml to add artifactPublishEnabled property.

--- a/Steps/IO/Files/src/DeleteFileOptions.cs
+++ b/Steps/IO/Files/src/DeleteFileOptions.cs
@@ -35,6 +35,11 @@ namespace MyTrout.Pipelines.Steps.IO.Files
     public class DeleteFileOptions
     {
         /// <summary>
+        /// Gets or sets the timing of when the <see cref="DeleteFileStep"/> will be executed.
+        /// </summary>
+        public ExecutionTimings ExecutionTimings { get; set; } = ExecutionTimings.After;
+
+        /// <summary>
         /// Gets or sets a base directory for the source file name.
         /// </summary>
         public string DeleteFileBaseDirectory { get; set; } = string.Empty;

--- a/Steps/IO/Files/src/FileUtility.cs
+++ b/Steps/IO/Files/src/FileUtility.cs
@@ -54,7 +54,7 @@ namespace MyTrout.Pipelines.Steps.IO.Files
 
             if (!basePath.EndsWith(Path.DirectorySeparatorChar))
             {
-                basePath = basePath + Path.DirectorySeparatorChar;
+                basePath += Path.DirectorySeparatorChar;
             }
 
             if (!Path.IsPathFullyQualified(result))

--- a/Steps/IO/Files/src/MoveFileOptions.cs
+++ b/Steps/IO/Files/src/MoveFileOptions.cs
@@ -35,6 +35,11 @@ namespace MyTrout.Pipelines.Steps.IO.Files
     public class MoveFileOptions
     {
         /// <summary>
+        /// Gets or sets the timing of when the <see cref="MoveFileStep"/> will be executed.
+        /// </summary>
+        public ExecutionTimings ExecutionTimings { get; set; } = ExecutionTimings.After;
+
+        /// <summary>
         /// Gets or sets a base directory for the source file name.
         /// </summary>
         public string MoveSourceFileBaseDirectory { get; set; } = string.Empty;

--- a/Steps/IO/Files/src/MyTrout.Pipelines.Steps.IO.Files.csproj
+++ b/Steps/IO/Files/src/MyTrout.Pipelines.Steps.IO.Files.csproj
@@ -35,32 +35,20 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.8.55">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="3.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="3.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.6.13">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="MyTrout.Pipelines.Steps" Version="[2.0.6,3.0)" />
+    <PackageReference Include="MyTrout.Pipelines.Steps" Version="[2.0.7,3.0)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.8.0.18411">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.17.0.26580">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.321">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Steps/IO/Files/src/WriteStreamToFileSystemOptions.cs
+++ b/Steps/IO/Files/src/WriteStreamToFileSystemOptions.cs
@@ -35,6 +35,11 @@ namespace MyTrout.Pipelines.Steps.IO.Files
     public class WriteStreamToFileSystemOptions
     {
         /// <summary>
+        /// Gets or sets the timing of when the <see cref="WriteStreamToFileSystemStep"/> will be executed.
+        /// </summary>
+        public ExecutionTimings ExecutionTimings { get; set; } = ExecutionTimings.After;
+
+        /// <summary>
         /// Gets or sets the base directory to which the application should write the file.
         /// </summary>
         public string WriteFileBaseDirectory { get; set; } = string.Empty;

--- a/Steps/IO/Files/test/MoveFileStepTests.cs
+++ b/Steps/IO/Files/test/MoveFileStepTests.cs
@@ -124,6 +124,66 @@ namespace MyTrout.Pipelines.Steps.IO.Files.Tests
         }
 
         [TestMethod]
+        public async Task Returns_PipelineContext_From_InvokeAsync_When_ExecutionTimings_Before_Is_Configured_And_File_Is_Moved_Successfully()
+        {
+            // arrange
+            string sourceFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}{Path.DirectorySeparatorChar}";
+            string targetFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}{Path.DirectorySeparatorChar}{Guid.NewGuid()}{Path.DirectorySeparatorChar}";
+
+            string fileName = $"{Guid.NewGuid()}.txt";
+
+            string fullSourcePathAndFileName = sourceFilePath + fileName;
+            string fullTargetPathAndFileName = targetFilePath + fileName;
+
+            string contents = "Et tu, Brute?";
+            File.WriteAllText(fullSourcePathAndFileName, contents);
+
+            PipelineContext context = new PipelineContext();
+            context.Items.Add(FileConstants.SOURCE_FILE, fileName);
+            context.Items.Add(FileConstants.TARGET_FILE, fileName);
+
+            var logger = new Mock<ILogger<MoveFileStep>>().Object;
+
+            Mock<IPipelineRequest> mockNext = new Mock<IPipelineRequest>();
+            mockNext.Setup(x => x.InvokeAsync(context))
+                                    .Callback(() => {
+                                        Assert.IsFalse(File.Exists(fullSourcePathAndFileName));
+                                        Assert.IsTrue(File.Exists(fullTargetPathAndFileName));
+                                        Assert.AreEqual(contents, File.ReadAllText(fullTargetPathAndFileName));
+                                    })
+                                    .Returns(Task.CompletedTask);
+
+            var next = mockNext.Object;
+
+            MoveFileOptions options = new MoveFileOptions()
+            {
+                ExecutionTimings = ExecutionTimings.Before,
+                MoveSourceFileBaseDirectory = sourceFilePath,
+                MoveTargetFileBaseDirectory = targetFilePath
+            };
+
+            var source = new MoveFileStep(logger, next, options);
+
+            // act
+            await source.InvokeAsync(context).ConfigureAwait(false);
+
+            // assert
+            if (context.Errors.Any())
+            {
+                throw context.Errors[0];
+            }
+
+            Assert.IsFalse(File.Exists(fullSourcePathAndFileName));
+            Assert.IsTrue(File.Exists(fullTargetPathAndFileName));
+            Assert.AreEqual(contents, File.ReadAllText(fullTargetPathAndFileName));
+
+            // cleanup
+            await source.DisposeAsync().ConfigureAwait(false);
+            File.Delete(fullTargetPathAndFileName);
+            Directory.Delete(targetFilePath);
+        }
+
+        [TestMethod]
         public async Task Returns_PipelineContext_Error_From_InvokeAsync_When_Source_File_Does_Not_Exists()
         {
             // arrange

--- a/Steps/IO/Files/test/MoveFileStepTests.cs
+++ b/Steps/IO/Files/test/MoveFileStepTests.cs
@@ -146,7 +146,8 @@ namespace MyTrout.Pipelines.Steps.IO.Files.Tests
 
             Mock<IPipelineRequest> mockNext = new Mock<IPipelineRequest>();
             mockNext.Setup(x => x.InvokeAsync(context))
-                                    .Callback(() => {
+                                    .Callback(() =>
+                                    {
                                         Assert.IsFalse(File.Exists(fullSourcePathAndFileName));
                                         Assert.IsTrue(File.Exists(fullTargetPathAndFileName));
                                         Assert.AreEqual(contents, File.ReadAllText(fullTargetPathAndFileName));


### PR DESCRIPTION
- Upgrade to MyTrout.Pipelines.Steps v2.0.7
- Upgrade all analyzers and remove deprecated analyzers.
- Add the ExecutionTimings to DeleteFileOptions, MoveFileOptions, and WriteStreamToFileSystemOptions.
- Add the ability to execute on the request or response side for DeleteFileStep, MoveFileStep, and WriteStreamToFileSystemStep.
- Correct analyzer warnings.