### PR TITLE
Correct the IDisposable/IAsyncDisposable implementation for CA1816

### DIFF
--- a/.github/workflows/build-pipelines-core.yaml
+++ b/.github/workflows/build-pipelines-core.yaml
@@ -85,18 +85,19 @@ jobs:
         if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
         
       
-      - name: Upload nupkg
-        uses: actions/upload-artifact@v2
-        with:
-          name: nupkg
-          path: ${{ env.WORKING_DIRECTORY }}/**/bin/Release/*.nupkg
-        if: "github.ref == 'refs/heads/master' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
+      #- name: Upload nupkg
+      #  uses: actions/upload-artifact@v2
+      #  with:
+      #    name: nupkg
+      #    path: ${{ env.WORKING_DIRECTORY }}/**/bin/Release/*.nupkg
+      #    if-no-files-found: error
+      #  if: "github.ref == 'refs/heads/master' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
         
-      - name: Publish the package to nuget.org
-        run: dotnet nuget push "../Pipelines/Core/src/bin/Release/*.nupkg" --api-key ${{ secrets.MYTROUT_NUGET_API_KEY }} --source "https://api.nuget.org/v3/index.json"
-        if: "github.ref == 'refs/heads/master' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
+      #- name: Publish the package to nuget.org
+      #  run: dotnet nuget push "../Pipelines/Core/src/bin/Release/*.nupkg" --api-key ${{ secrets.MYTROUT_NUGET_API_KEY }} --source "https://api.nuget.org/v3/index.json"
+      #  if: "github.ref == 'refs/heads/master' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
 
-      - name: Publish the package to GitHub.
-        run: dotnet nuget push "../Pipelines/Core/src/bin/Release/*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/mytrout/index.json"
-        if: "github.ref == 'refs/heads/master' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
+      #- name: Publish the package to GitHub.
+      #  run: dotnet nuget push "../Pipelines/Core/src/bin/Release/*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/mytrout/index.json"
+      #  if: "github.ref == 'refs/heads/master' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
  

--- a/Core/changelog.md
+++ b/Core/changelog.md
@@ -1,5 +1,16 @@
 # MyTrout.Pipelines.Core Change Log
 
+## 3.2.0 - SonarCloud UPDATE ONLY
+- Suppress CA2254 to prevent false positives in SonarCloud.io with culture-aware logging messages
+- Correct test project steps to conform with CA1816 warning
+- Simplify loop to use LINQ expression in RenameContextItemstep to conform with S3267
+= Install Microsoft.CodeAnalysis.NetAnalyzers 3.3.0
+- Install Roslynator.Analyzers 3.3.0
+- Install SonarAnalyzer.CSharp 8.33.0.40503
+- Commented out ability to publish to nuget or github to ensure this update does not cause a build failure.
+- Add "if-no-files-found: error" to the nuget publishing step. (see Issue #94)
+- NOTE TO DEVELOPERS: Developers must reverse the removal of nuget and github publishing when the next version is ready to be released
+
 ## 3.2.0
 - Upgrade to .NET 6.0
 - Upgrade libraries to 6.0.0 versions.

--- a/Core/src/MyTrout.Pipelines.csproj
+++ b/Core/src/MyTrout.Pipelines.csproj
@@ -23,7 +23,7 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <ErrorReport>prompt</ErrorReport>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
-    <NoWarn>1701;1702;SA1413;SA1636;S4792</NoWarn>
+    <NoWarn>1701;1702;SA1413;CA2254;SA1636;S4792</NoWarn>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <IncludeSymbols>true</IncludeSymbols>
@@ -39,11 +39,19 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.0.64">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.33.0.40503">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Core/src/Steps/AbstractPipelineStep{TStep}.cs
+++ b/Core/src/Steps/AbstractPipelineStep{TStep}.cs
@@ -76,11 +76,8 @@ namespace MyTrout.Pipelines.Steps
             // Dispose of synchronous unmanaged resources.
             this.Dispose(false);
 
-#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
-
             // Suppress finalization.
             GC.SuppressFinalize(this);
-#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
         }
 
         /// <summary>

--- a/Core/src/Steps/RenameContextItemStep.cs
+++ b/Core/src/Steps/RenameContextItemStep.cs
@@ -26,6 +26,7 @@ namespace MyTrout.Pipelines.Steps
 {
     using Microsoft.Extensions.Logging;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -83,14 +84,11 @@ namespace MyTrout.Pipelines.Steps
             }
             finally
             {
-                foreach (var renamedKey in this.Options.RenameValues.Values)
+                foreach (var renamedKey in this.Options.RenameValues.Values.Where(x => context.Items.ContainsKey(x)))
                 {
-                    if (context.Items.ContainsKey(renamedKey))
-                    {
-                        // Restoration of the original contextKey is unnecessary because the AbstractCachingPipelineStep handles it.
-                        context.Items.Remove(renamedKey);
-                        this.Logger.LogDebug("Removed '{renamedKey}' from Pipeline.Items.", renamedKey);
-                    }
+                    // Restoration of the original contextKey is unnecessary because the AbstractCachingPipelineStep handles it.
+                    context.Items.Remove(renamedKey);
+                    this.Logger.LogDebug("Removed '{renamedKey}' from Pipeline.Items.", renamedKey);
                 }
             }
         }

--- a/Core/test/Samples/SampleStep1.cs
+++ b/Core/test/Samples/SampleStep1.cs
@@ -43,11 +43,16 @@ namespace MyTrout.Pipelines.Samples.Tests
             GC.SuppressFinalize(this);
         }
 
-        public ValueTask DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
+            // Perform async cleanup.
+            await this.DisposeCoreAsync();
+
+            // Dispose of synchronous unmanaged resources.
             this.Dispose(false);
 
-            return new ValueTask(Task.CompletedTask);
+            // Suppress finalization.
+            GC.SuppressFinalize(this);
         }
 
         public Task InvokeAsync(IPipelineContext context)
@@ -72,10 +77,19 @@ namespace MyTrout.Pipelines.Samples.Tests
         /// <summary>
         /// Disposes of any disposable resources for this instance.
         /// </summary>
-        /// <param name="disposing">Determines if this method needs to dispose unmanaged resources.</param>
+        /// <param name="disposing">A flag indicating whether this instance is already being disposed.</param>
         protected virtual void Dispose(bool disposing)
         {
             // no op
+        }
+
+        /// <summary>
+        /// Disposes of any asynchronous disposable resources for this instance.
+        /// </summary>
+        /// <returns>A completed <see cref="ValueTask" />.</returns>
+        protected virtual ValueTask DisposeCoreAsync()
+        {
+            return default;
         }
     }
 }

--- a/Core/test/Samples/SampleWithConstructorParameterStep.cs
+++ b/Core/test/Samples/SampleWithConstructorParameterStep.cs
@@ -48,11 +48,16 @@ namespace MyTrout.Pipelines.Samples.Tests
             GC.SuppressFinalize(this);
         }
 
-        public ValueTask DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
+            // Perform async cleanup.
+            await this.DisposeCoreAsync();
+
+            // Dispose of synchronous unmanaged resources.
             this.Dispose(false);
 
-            return new ValueTask(Task.CompletedTask);
+            // Suppress finalization.
+            GC.SuppressFinalize(this);
         }
 
         public Task InvokeAsync(IPipelineContext context)
@@ -63,10 +68,19 @@ namespace MyTrout.Pipelines.Samples.Tests
         /// <summary>
         /// Disposes of any disposable resources for this instance.
         /// </summary>
-        /// <param name="disposing">Determines if this method needs to dispose unmanaged resources.</param>
+        /// <param name="disposing">A flag indicating whether this instance is already being disposed.</param>
         protected virtual void Dispose(bool disposing)
         {
             // no op
+        }
+
+        /// <summary>
+        /// Disposes of any asynchronous disposable resources for this instance.
+        /// </summary>
+        /// <returns>A completed <see cref="ValueTask" />.</returns>
+        protected virtual ValueTask DisposeCoreAsync()
+        {
+            return default;
         }
     }
 }

--- a/Core/test/Samples/SampleWithInvokeAsyncMethodStep.cs
+++ b/Core/test/Samples/SampleWithInvokeAsyncMethodStep.cs
@@ -41,18 +41,28 @@ namespace MyTrout.Pipelines.Samples.Tests
 
         private IPipelineRequest Next { get; }
 
+        /// <inheritdoc />
         public void Dispose()
         {
-            this.Dispose(disposing: true);
-
+            this.Dispose(true);
             GC.SuppressFinalize(this);
         }
 
-        public ValueTask DisposeAsync()
+        /// <summary>
+        /// Disposes of any disposable resources for this instance.
+        /// </summary>
+        /// <returns>A completed <see cref="ValueTask" />.</returns>
+        /// <remarks>Developers who need to dispose of unmanaged resources should override this method.</remarks>
+        public async ValueTask DisposeAsync()
         {
+            // Perform async cleanup.
+            await this.DisposeCoreAsync();
+
+            // Dispose of synchronous unmanaged resources.
             this.Dispose(false);
 
-            return new ValueTask(Task.CompletedTask);
+            // Suppress finalization.
+            GC.SuppressFinalize(this);
         }
 
         public Task InvokeAsync(IPipelineContext context)
@@ -63,10 +73,19 @@ namespace MyTrout.Pipelines.Samples.Tests
         /// <summary>
         /// Disposes of any disposable resources for this instance.
         /// </summary>
-        /// <param name="disposing">Determines if this method needs to dispose unmanaged resources.</param>
+        /// <param name="disposing">A flag indicating whether this instance is already being disposed.</param>
         protected virtual void Dispose(bool disposing)
         {
             // no op
+        }
+
+        /// <summary>
+        /// Disposes of any asynchronous disposable resources for this instance.
+        /// </summary>
+        /// <returns>A completed <see cref="ValueTask" />.</returns>
+        protected virtual ValueTask DisposeCoreAsync()
+        {
+            return default;
         }
     }
 }

--- a/Core/test/Samples/SampleWithLoggerStep.cs
+++ b/Core/test/Samples/SampleWithLoggerStep.cs
@@ -1,7 +1,7 @@
 ﻿// <copyright file="SampleWithLoggerStep.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2019-2020 Chris Trout
+// Copyright © 2019-2021 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -41,16 +41,28 @@ namespace MyTrout.Pipelines.Samples.Tests
 
         private IPipelineRequest Next { get; }
 
+        /// <inheritdoc />
         public void Dispose()
         {
             this.Dispose(true);
             GC.SuppressFinalize(this);
         }
 
-        public ValueTask DisposeAsync()
+        /// <summary>
+        /// Disposes of any disposable resources for this instance.
+        /// </summary>
+        /// <returns>A completed <see cref="ValueTask" />.</returns>
+        /// <remarks>Developers who need to dispose of unmanaged resources should override this method.</remarks>
+        public async ValueTask DisposeAsync()
         {
+            // Perform async cleanup.
+            await this.DisposeCoreAsync();
+
+            // Dispose of synchronous unmanaged resources.
             this.Dispose(false);
-            return default;
+
+            // Suppress finalization.
+            GC.SuppressFinalize(this);
         }
 
         public Task InvokeAsync(IPipelineContext context)
@@ -61,10 +73,19 @@ namespace MyTrout.Pipelines.Samples.Tests
         /// <summary>
         /// Disposes of any disposable resources for this instance.
         /// </summary>
-        /// <param name="disposing">Determines if this method needs to dispose unmanaged resources.</param>
+        /// <param name="disposing">A flag indicating whether this instance is already being disposed.</param>
         protected virtual void Dispose(bool disposing)
         {
             // no op
+        }
+
+        /// <summary>
+        /// Disposes of any asynchronous disposable resources for this instance.
+        /// </summary>
+        /// <returns>A completed <see cref="ValueTask" />.</returns>
+        protected virtual ValueTask DisposeCoreAsync()
+        {
+            return default;
         }
     }
 }

--- a/Core/test/Samples/SampleWithoutIPipelineRequestStep.cs
+++ b/Core/test/Samples/SampleWithoutIPipelineRequestStep.cs
@@ -1,7 +1,7 @@
 ﻿// <copyright file="SampleWithoutIPipelineRequestStep.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2019-2020 Chris Trout
+// Copyright © 2019-2021 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -28,14 +28,51 @@ namespace MyTrout.Pipelines.Samples.Tests
     using System.Threading.Tasks;
 
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    public class SampleWithoutIPipelineRequestStep : IAsyncDisposable
+    public class SampleWithoutIPipelineRequestStep : IAsyncDisposable, IDisposable
     {
         public SampleWithoutIPipelineRequestStep()
         {
             // no op
         }
 
-        public ValueTask DisposeAsync()
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes of any disposable resources for this instance.
+        /// </summary>
+        /// <returns>A completed <see cref="ValueTask" />.</returns>
+        /// <remarks>Developers who need to dispose of unmanaged resources should override this method.</remarks>
+        public async ValueTask DisposeAsync()
+        {
+            // Perform async cleanup.
+            await this.DisposeCoreAsync();
+
+            // Dispose of synchronous unmanaged resources.
+            this.Dispose(false);
+
+            // Suppress finalization.
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes of any disposable resources for this instance.
+        /// </summary>
+        /// <param name="disposing">A flag indicating whether this instance is already being disposed.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            // no op
+        }
+
+        /// <summary>
+        /// Disposes of any asynchronous disposable resources for this instance.
+        /// </summary>
+        /// <returns>A completed <see cref="ValueTask" />.</returns>
+        protected virtual ValueTask DisposeCoreAsync()
         {
             return default;
         }

--- a/Core/test/Samples/SampleWithoutNextInConstructorStep.cs
+++ b/Core/test/Samples/SampleWithoutNextInConstructorStep.cs
@@ -1,7 +1,7 @@
 ﻿// <copyright file="SampleWithoutNextInConstructorStep.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2019-2020 Chris Trout
+// Copyright © 2019-2021 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -38,16 +38,28 @@ namespace MyTrout.Pipelines.Samples.Tests
 
         private ILogger<SampleWithoutNextInConstructorStep> Logger { get; }
 
+        /// <inheritdoc />
         public void Dispose()
         {
             this.Dispose(true);
             GC.SuppressFinalize(this);
         }
 
-        public ValueTask DisposeAsync()
+        /// <summary>
+        /// Disposes of any disposable resources for this instance.
+        /// </summary>
+        /// <returns>A completed <see cref="ValueTask" />.</returns>
+        /// <remarks>Developers who need to dispose of unmanaged resources should override this method.</remarks>
+        public async ValueTask DisposeAsync()
         {
+            // Perform async cleanup.
+            await this.DisposeCoreAsync();
+
+            // Dispose of synchronous unmanaged resources.
             this.Dispose(false);
-            return default;
+
+            // Suppress finalization.
+            GC.SuppressFinalize(this);
         }
 
         public Task InvokeAsync(IPipelineContext context)
@@ -58,10 +70,19 @@ namespace MyTrout.Pipelines.Samples.Tests
         /// <summary>
         /// Disposes of any disposable resources for this instance.
         /// </summary>
-        /// <param name="disposing">Determines if this method needs to dispose unmanaged resources.</param>
+        /// <param name="disposing">A flag indicating whether this instance is already being disposed.</param>
         protected virtual void Dispose(bool disposing)
         {
             // no op
+        }
+
+        /// <summary>
+        /// Disposes of any asynchronous disposable resources for this instance.
+        /// </summary>
+        /// <returns>A completed <see cref="ValueTask" />.</returns>
+        protected virtual ValueTask DisposeCoreAsync()
+        {
+            return default;
         }
     }
 }


### PR DESCRIPTION
Correct the IDisposable/IAsyncDisposable implementation for CA1816
Simplify loop expression with Linq for S3267
Suppress the CA2254 warning for MyTrout.Pipelines.Core.