### PR TITLE
Pipelines.Steps.Azure.ServiceBus code coverage showing 94.1% code coverage after altcover upgrade.

### DIFF
--- a/.github/workflows/build-pipelines-steps-azure-servicebus.yaml
+++ b/.github/workflows/build-pipelines-steps-azure-servicebus.yaml
@@ -28,7 +28,7 @@ env:
   SOLUTION_NAME: 'MyTrout.Pipelines.Steps.Azure.ServiceBus.sln'
         
   # This value should change on each deployable version of this solution.
-  PROJECT_VERSION: '3.1.0'  
+  PROJECT_VERSION: '4.0.0'  
 
   # These values are used for creating an Azure SQL Server Database
   # Azure Servers cannot have periods, underscores, or upper case letters in the name.

--- a/Steps/Azure/ServiceBus/README.md
+++ b/Steps/Azure/ServiceBus/README.md
@@ -36,6 +36,10 @@ All software dependencies listed above use the [MIT License](https://licenses.nu
 
 
 ## BREAKING CHANGES FROM v1.x to V2.0
+- ReadMessageFromAzureStep will always copy all ApplicationProperties values from a message into PipelineContext.Items with a prefix provided by ReadMessageFromAzureOptions.
+- ReadMessageFromAzureOptions.ApplicationProperties has been removed permanently.
+
+## BREAKING CHANGES FROM v1.x to V2.0
 - Update from .NET Standard 2.1 to .NET 5.0
 
 ## How do I use the steps in this library ([ReadMessageFromAzureStep](./src/ReadMessageFromAzureStep.cs)) ?

--- a/Steps/Azure/ServiceBus/README.md
+++ b/Steps/Azure/ServiceBus/README.md
@@ -35,15 +35,16 @@ For more details on Pipelines, see [Pipelines.Core](../../../Core/)
 All software dependencies listed above use the [MIT License](https://licenses.nuget.org/MIT).
 
 
-## BREAKING CHANGES FROM v1.x to V2.0
+## BREAKING CHANGES FROM v3.x to v4.x
+- Supports .NET 6.0 and .NET 5.0
 - ReadMessageFromAzureStep will always copy all ApplicationProperties values from a message into PipelineContext.Items with a prefix provided by ReadMessageFromAzureOptions.
 - ReadMessageFromAzureOptions.ApplicationProperties has been removed permanently.
 - WriteMessageToAzureStep will always copy all ApplicationProperties values from PipelineContext.Items to the message with a prefix provided by WriteMessageToAzureOptions.
 - WriteMessageToAzureOptions.ApplicationProperties has been removed permanently.
 
+## BREAKING CHANGES FROM v2.x to v3.x
+- Drop support for .NET Standard 2.1
 
-## BREAKING CHANGES FROM v1.x to V2.0
-- Update from .NET Standard 2.1 to .NET 5.0
 
 ## How do I use the steps in this library ([ReadMessageFromAzureStep](./src/ReadMessageFromAzureStep.cs)) ?
 

--- a/Steps/Azure/ServiceBus/README.md
+++ b/Steps/Azure/ServiceBus/README.md
@@ -38,6 +38,9 @@ All software dependencies listed above use the [MIT License](https://licenses.nu
 ## BREAKING CHANGES FROM v1.x to V2.0
 - ReadMessageFromAzureStep will always copy all ApplicationProperties values from a message into PipelineContext.Items with a prefix provided by ReadMessageFromAzureOptions.
 - ReadMessageFromAzureOptions.ApplicationProperties has been removed permanently.
+- WriteMessageToAzureStep will always copy all ApplicationProperties values from PipelineContext.Items to the message with a prefix provided by WriteMessageToAzureOptions.
+- WriteMessageToAzureOptions.ApplicationProperties has been removed permanently.
+
 
 ## BREAKING CHANGES FROM v1.x to V2.0
 - Update from .NET Standard 2.1 to .NET 5.0

--- a/Steps/Azure/ServiceBus/changelog.md
+++ b/Steps/Azure/ServiceBus/changelog.md
@@ -1,4 +1,7 @@
 # MyTrout.Pipelines.Steps.Azure.ServiceBus Change Log
+## 4.0.0
+ - (BREAKING CHANGE) - ReadMessageFromAzureStep will always copy all ApplicationProperties values from a message into PipelineContext.Items with a prefix provided by ReadMessageFromAzureOptions.
+ - (BREAKING CHANGE) - ReadMessageFromAzureOptions.ApplicationProperties has been removed permanently.
 
 ## 3.1.0
  - Upgrade to .NET 6.0 while maintaining 5.0 support.

--- a/Steps/Azure/ServiceBus/changelog.md
+++ b/Steps/Azure/ServiceBus/changelog.md
@@ -2,6 +2,11 @@
 ## 4.0.0
  - (BREAKING CHANGE) - ReadMessageFromAzureStep will always copy all ApplicationProperties values from a message into PipelineContext.Items with a prefix provided by ReadMessageFromAzureOptions.
  - (BREAKING CHANGE) - ReadMessageFromAzureOptions.ApplicationProperties has been removed permanently.
+ - (BREAKING CHANGE) - ReadMessageFromAzureStep.EvaluateCancellationOfMessageAsync method was refactored to allow integration testing to use a change in this method instead of a protected setter on the ServiceBusReceiver property.
+ - (BREAKING CHANGE) - ReadMessageFromAzureStep.ServiceBusReceiver is no longer a protected setter; it is read-only after construction.
+ - (BREAKING CHANGE) - WriteMessageToAzureOptions.ApplicationProperties has been removed permanently.
+ - (BREAKING CHANGE) - WriteMessageToAzureStep will always copy all PipelineContext.Items values prefixed with WriteMessageToAzureOptions.MessageContextItemsPrefix to the message being sent.
+ - Correction of StyleCop and other analyzers to ensure consistency across projects.
 
 ## 3.1.0
  - Upgrade to .NET 6.0 while maintaining 5.0 support.

--- a/Steps/Azure/ServiceBus/src/ReadMessageFromAzureOptions.cs
+++ b/Steps/Azure/ServiceBus/src/ReadMessageFromAzureOptions.cs
@@ -1,7 +1,7 @@
 ﻿// <copyright file="ReadMessageFromAzureOptions.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2019-2020 Chris Trout
+// Copyright(c) 2019-2022 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +23,7 @@
 // </copyright>
 namespace MyTrout.Pipelines.Steps.Azure.ServiceBus
 {
+    using global::Azure.Messaging.ServiceBus;
     using System;
     using System.Collections.Generic;
 
@@ -44,11 +45,6 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus
         /// Gets or sets the connection string for Azure Service Bus.
         /// </summary>
         public string AzureServiceBusConnectionString { get; set; } = string.Empty;
-
-        /// <summary>
-        /// Gets or sets UserProperty names that will be added to the Message from <see cref="MyTrout.Pipelines.Core.PipelineContext" />, if they are available.
-        /// </summary>
-        public IEnumerable<string> ApplicationProperties { get; set; } = new List<string>();
 
         /// <summary>
         /// Gets or sets the number of messages to download for each request to Azure Service Bus.
@@ -76,6 +72,11 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus
                 return new ServiceBusReadEntity(this.EntityPath);
             }
         }
+
+        /// <summary>
+        /// Gets or sets the prefix for keys of <see cref="ServiceBusReceivedMessage.ApplicationProperties"/> when copied to <see cref="IPipelineContext.Items"/>.
+        /// </summary>
+        public string MessageContextItemsPrefix { get; set; } = "MSG_";
 
         /// <summary>
         /// Gets or sets the time this step will wait for a new message until it times out.

--- a/Steps/Azure/ServiceBus/src/ReadMessageFromAzureStep.cs
+++ b/Steps/Azure/ServiceBus/src/ReadMessageFromAzureStep.cs
@@ -90,14 +90,14 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus
         /// <returns>A completed <see cref="ValueTask"/>.</returns>
         protected async override ValueTask DisposeCoreAsync()
         {
-            if (this.ServiceBusClient != null)
-            {
-                await this.ServiceBusReceiver.CloseAsync().ConfigureAwait(false);
-            }
-
             if (this.ServiceBusReceiver != null)
             {
                 await this.ServiceBusReceiver.DisposeAsync().ConfigureAwait(false);
+            }
+
+            if (this.ServiceBusClient != null)
+            {
+                await this.ServiceBusClient.DisposeAsync().ConfigureAwait(false);
             }
         }
 

--- a/Steps/Azure/ServiceBus/src/ReadMessageFromAzureStep.cs
+++ b/Steps/Azure/ServiceBus/src/ReadMessageFromAzureStep.cs
@@ -99,6 +99,8 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus
             {
                 await this.ServiceBusClient.DisposeAsync().ConfigureAwait(false);
             }
+
+            await base.DisposeCoreAsync().ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Steps/Azure/ServiceBus/src/ReadMessageFromAzureStep.cs
+++ b/Steps/Azure/ServiceBus/src/ReadMessageFromAzureStep.cs
@@ -1,7 +1,7 @@
 ﻿// <copyright file="ReadMessageFromAzureStep.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2019-2021 Chris Trout
+// Copyright(c) 2019-2022 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -77,8 +77,10 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus
         /// </summary>
         public ServiceBusClient ServiceBusClient { get; init; }
 
+        // DEVELOPERS NOTE: This property is specifically protected set because unit testing needs it this way instead of init.
+
         /// <summary>
-        /// Gets or sets the Azure Service Bus message receiver.
+        /// Gets or setsthe Azure Service Bus message receiver.
         /// </summary>
         public ServiceBusReceiver ServiceBusReceiver { get; protected set; }
 
@@ -207,9 +209,9 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus
             try
             {
                 // Add the values in ApplicationProperties to the context.
-                foreach (var key in this.Options.ApplicationProperties.Where(x => message.ApplicationProperties.ContainsKey(x)))
+                foreach (var key in message.ApplicationProperties.Keys)
                 {
-                    context.Items.Add(key, message.ApplicationProperties[key]);
+                    context.Items.Add($"{this.Options.MessageContextItemsPrefix}{key}", message.ApplicationProperties[key]);
                 }
 
                 // Load inputStream and pass it into the InvokeAsync().
@@ -231,9 +233,9 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus
                 }
 
                 // Remove the values in ApplicationProperties from the context.
-                foreach (var key in this.Options.ApplicationProperties.Where(x => message.ApplicationProperties.ContainsKey(x)))
+                foreach (var key in message.ApplicationProperties.Keys)
                 {
-                    context.Items.Remove(key);
+                    context.Items.Remove($"{this.Options.MessageContextItemsPrefix}{key}");
                 }
 
                 if (context.Errors.Count > errorCount)

--- a/Steps/Azure/ServiceBus/src/ServiceBusReadEntity.cs
+++ b/Steps/Azure/ServiceBus/src/ServiceBusReadEntity.cs
@@ -37,21 +37,23 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus
         /// <param name="entityPath">A value representing either a queue or subscription with topic name.</param>
         public ServiceBusReadEntity(string entityPath)
         {
-            this.EntityPath = entityPath ?? throw new ArgumentNullException(nameof(entityPath));
-
-            if (!string.IsNullOrWhiteSpace(this.EntityPath))
+            if (string.IsNullOrWhiteSpace(entityPath))
             {
-                if (!this.EntityPath.Contains('/'))
-                {
-                    this.Kind = ServiceBusReadEntityKind.Queue;
-                    this.QueueName = entityPath;
-                }
-                else if (this.EntityPath.IndexOf('/') == this.EntityPath.LastIndexOf('/'))
-                {
-                    this.Kind = ServiceBusReadEntityKind.Subscription;
-                    this.SubscriptionName = this.EntityPath.Substring(startIndex: this.EntityPath.IndexOf('/') + 1);
-                    this.TopicName = this.EntityPath.Substring(startIndex: 0, length: this.EntityPath.IndexOf('/'));
-                }
+                throw new ArgumentNullException(nameof(entityPath));
+            }
+
+            this.EntityPath = entityPath;
+
+            if (!this.EntityPath.Contains('/'))
+            {
+                this.Kind = ServiceBusReadEntityKind.Queue;
+                this.QueueName = entityPath;
+            }
+            else if (this.EntityPath.IndexOf('/') == this.EntityPath.LastIndexOf('/'))
+            {
+                this.Kind = ServiceBusReadEntityKind.Subscription;
+                this.SubscriptionName = this.EntityPath.Substring(startIndex: this.EntityPath.IndexOf('/') + 1);
+                this.TopicName = this.EntityPath.Substring(startIndex: 0, length: this.EntityPath.IndexOf('/'));
             }
         }
 

--- a/Steps/Azure/ServiceBus/src/ServiceBusReadEntity.cs
+++ b/Steps/Azure/ServiceBus/src/ServiceBusReadEntity.cs
@@ -1,7 +1,7 @@
 ﻿// <copyright file="ServiceBusReadEntity.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2019-2020 Chris Trout
+// Copyright(c) 2019-2022 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Steps/Azure/ServiceBus/src/WriteMessageToAzureOptions.cs
+++ b/Steps/Azure/ServiceBus/src/WriteMessageToAzureOptions.cs
@@ -24,8 +24,8 @@
 
 namespace MyTrout.Pipelines.Steps.Azure.ServiceBus
 {
+    using global::Azure.Messaging.ServiceBus;
     using System;
-    using System.Collections.Generic;
 
     /// <summary>
     /// Provides user-configurable options for the <see cref="WriteMessageToAzureStep" /> step.
@@ -43,14 +43,14 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus
         }
 
         /// <summary>
-        /// Gets or sets UserProperty names that will be added to the Message from <see cref="MyTrout.Pipelines.Core.PipelineContext" />, if they are available.
-        /// </summary>
-        public IEnumerable<string> ApplicationProperties { get; set; } = new List<string>();
-
-        /// <summary>
         /// Gets or sets the connection string for Azure Service Bus.
         /// </summary>
         public string AzureServiceBusConnectionString { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the prefix for keys in <see cref="IPipelineContext.Items"/> that should be copied to <see cref="ServiceBusMessage.ApplicationProperties"/>.
+        /// </summary>
+        public string MessageContextItemsPrefix { get; set; } = "MSG_";
 
         /// <summary>
         /// Gets or sets the Queue or Topic Name to which the message will be written.

--- a/Steps/Azure/ServiceBus/src/WriteMessageToAzureOptions.cs
+++ b/Steps/Azure/ServiceBus/src/WriteMessageToAzureOptions.cs
@@ -1,7 +1,7 @@
 ﻿// <copyright file="WriteMessageToAzureOptions.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2019-2020 Chris Trout
+// Copyright(c) 2019-2022 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Steps/Azure/ServiceBus/src/WriteMessageToAzureStep.cs
+++ b/Steps/Azure/ServiceBus/src/WriteMessageToAzureStep.cs
@@ -27,8 +27,8 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus
     using global::Azure.Messaging.ServiceBus;
     using Microsoft.Extensions.Logging;
     using System;
-    using System.Globalization;
     using System.IO;
+    using System.Linq;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -67,7 +67,7 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus
         {
             if (this.ServiceBusSender != null)
             {
-                await this.ServiceBusSender.CloseAsync().ConfigureAwait(false);
+                await this.ServiceBusSender.DisposeAsync().ConfigureAwait(false);
             }
 
             if (this.ServiceBusClient != null)
@@ -116,11 +116,7 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus
 
             var outputStream = context.Items[PipelineContextConstants.OUTPUT_STREAM] as Stream;
 
-#pragma warning disable CS8604 // context.AssertValueIsValue(OUTPUT_STREAM) ensures that outputStream is not null when converted to a Stream.
-
-            var messageBody = await BinaryData.FromStreamAsync(outputStream);
-
-#pragma warning restore CS8604
+            var messageBody = await BinaryData.FromStreamAsync(outputStream!);
 
             var result = new ServiceBusMessage(messageBody);
 
@@ -134,16 +130,9 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus
             }
 
             // Sets UserProperties aka Filter Values on the Message, if they are available in the context.
-            foreach (var userProperty in this.Options.ApplicationProperties)
+            foreach (var userProperty in context.Items.Keys.Where(x => x.StartsWith(this.Options.MessageContextItemsPrefix)))
             {
-                if (context.Items.ContainsKey(userProperty))
-                {
-                    result.ApplicationProperties.Add(userProperty, context.Items[userProperty]);
-                }
-                else
-                {
-                    this.Logger.LogDebug(Resources.USER_PROPERTY_MISSING(CultureInfo.CurrentCulture, result.CorrelationId, userProperty));
-                }
+                result.ApplicationProperties.Add(userProperty.Substring(this.Options.MessageContextItemsPrefix.Length), context.Items[userProperty]);
             }
 
             return result;

--- a/Steps/Azure/ServiceBus/src/WriteMessageToAzureStep.cs
+++ b/Steps/Azure/ServiceBus/src/WriteMessageToAzureStep.cs
@@ -1,7 +1,7 @@
 ﻿// <copyright file="WriteMessageToAzureStep.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2019-2020 Chris Trout
+// Copyright(c) 2019-2022 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Steps/Azure/ServiceBus/test/ReadMessageFromAzureStepTests.cs
+++ b/Steps/Azure/ServiceBus/test/ReadMessageFromAzureStepTests.cs
@@ -69,6 +69,28 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
         }
 
         [TestMethod]
+        public async Task Disposes_ReadMessageFromAzureStep_Successfully()
+        {
+            // arrange
+            ILogger<ReadMessageFromAzureStep> logger = new Mock<ILogger<ReadMessageFromAzureStep>>().Object;
+            var next = new Mock<IPipelineRequest>().Object;
+            var options = new ReadMessageFromAzureOptions()
+            {
+                AzureServiceBusConnectionString = TestConstants.AzureServiceBusConnectionString,
+                EntityPath = "${TestConstants.MissingTopicName}/{TestConstants.MissingSubscriptionName}"
+            };
+
+            
+            var sut = new TestOverrideReadMessageFromAzureDisposeStep(logger, options, next);
+
+            // act
+            await sut.DisposeAsync();
+
+            // No exceptions is success.
+            // This test is to test if Dispose can handle both of the IDisposable properties being null.
+        }
+
+        [TestMethod]
         public async Task Returns_PipelineContext_Error_And_Abandoned_Message_From_InvokeAsync()
         {
             // arrange

--- a/Steps/Azure/ServiceBus/test/ReadMessageFromAzureStepTests.cs
+++ b/Steps/Azure/ServiceBus/test/ReadMessageFromAzureStepTests.cs
@@ -87,7 +87,9 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
             await sut.DisposeAsync();
 
             // assert
-            Assert.IsNull(sut);
+            // No exception means that everything went well.
+            Assert.IsTrue(true);
+
         }
 
         [TestMethod]

--- a/Steps/Azure/ServiceBus/test/ReadMessageFromAzureStepTests.cs
+++ b/Steps/Azure/ServiceBus/test/ReadMessageFromAzureStepTests.cs
@@ -86,8 +86,8 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
             // act
             await sut.DisposeAsync();
 
-            // No exceptions is success.
-            // This test is to test if Dispose can handle both of the IDisposable properties being null.
+            // assert
+            Assert.IsNull(sut);
         }
 
         [TestMethod]
@@ -96,15 +96,15 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
             // arrange
             ILogger<ReadMessageFromAzureStep> logger = new Mock<ILogger<ReadMessageFromAzureStep>>().Object;
 
-            PipelineContext context = new PipelineContext();
+            var context = new PipelineContext();
 
             string messageValue = "Are you there?";
-            Mock<IPipelineRequest> mockPipelineRequest = new Mock<IPipelineRequest>();
+            var mockPipelineRequest = new Mock<IPipelineRequest>();
             mockPipelineRequest.Setup(x => x.InvokeAsync(context))
                                 .Callback(() =>
                                 {
                                     context.Errors.Add(new InvalidDataException());
-                                    CancellationTokenSource tokenSource = new CancellationTokenSource();
+                                    var tokenSource = new CancellationTokenSource();
                                     tokenSource.Cancel();
                                     context.CancellationToken = tokenSource.Token;
 
@@ -129,7 +129,7 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
 
             byte[] messageBody = Encoding.UTF8.GetBytes(messageValue);
 
-            ServiceBusMessage message = new ServiceBusMessage(messageBody);
+            var message = new ServiceBusMessage(messageBody);
 
             await sender.SendMessageAsync(message).ConfigureAwait(false);
             await sender.CloseAsync().ConfigureAwait(false);
@@ -159,10 +159,10 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
             // arrange
             ILogger<ReadMessageFromAzureStep> logger = new Mock<ILogger<ReadMessageFromAzureStep>>().Object;
 
-            PipelineContext context = new PipelineContext();
+            var context = new PipelineContext();
 
             string messageValue = "Are you there?";
-            Mock<IPipelineRequest> mockPipelineRequest = new Mock<IPipelineRequest>();
+            var mockPipelineRequest = new Mock<IPipelineRequest>();
             mockPipelineRequest.Setup(x => x.InvokeAsync(context))
                                 .Callback(() =>
                                 {
@@ -189,7 +189,7 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
 
             byte[] messageBody = Encoding.UTF8.GetBytes(messageValue);
 
-            ServiceBusMessage message = new ServiceBusMessage(messageBody);
+            var message = new ServiceBusMessage(messageBody);
 
             await sender.SendMessageAsync(message).ConfigureAwait(false);
             await sender.CloseAsync().ConfigureAwait(false);
@@ -219,14 +219,14 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
             // arrange
             ILogger<ReadMessageFromAzureStep> logger = new Mock<ILogger<ReadMessageFromAzureStep>>().Object;
 
-            PipelineContext context = new PipelineContext();
+            var context = new PipelineContext();
 
             string messageValue = "Are you there?";
-            Mock<IPipelineRequest> mockPipelineRequest = new Mock<IPipelineRequest>();
+            var mockPipelineRequest = new Mock<IPipelineRequest>();
             mockPipelineRequest.Setup(x => x.InvokeAsync(context))
                                 .Callback(() =>
                                 {
-                                    CancellationTokenSource tokenSource = new CancellationTokenSource();
+                                    var tokenSource = new CancellationTokenSource();
                                     tokenSource.Cancel();
                                     context.CancellationToken = tokenSource.Token;
                                 })
@@ -248,7 +248,7 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
 
             byte[] messageBody = Encoding.UTF8.GetBytes(messageValue);
 
-            ServiceBusMessage message = new ServiceBusMessage(messageBody);
+            var message = new ServiceBusMessage(messageBody);
 
             await sender.SendMessageAsync(message).ConfigureAwait(false);
             await sender.SendMessageAsync(message).ConfigureAwait(false);
@@ -278,14 +278,14 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
             // arrange
             ILogger<ReadMessageFromAzureStep> logger = new Mock<ILogger<ReadMessageFromAzureStep>>().Object;
 
-            PipelineContext context = new PipelineContext();
+            var context = new PipelineContext();
 
             string messageValue = "Are you there?";
-            Mock<IPipelineRequest> mockPipelineRequest = new Mock<IPipelineRequest>();
+            var mockPipelineRequest = new Mock<IPipelineRequest>();
             mockPipelineRequest.Setup(x => x.InvokeAsync(context))
                                 .Callback(() =>
                                 {
-                                    CancellationTokenSource tokenSource = new CancellationTokenSource();
+                                    var tokenSource = new CancellationTokenSource();
                                     tokenSource.Cancel();
                                     context.CancellationToken = tokenSource.Token;
                                 })
@@ -307,7 +307,7 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
 
             byte[] messageBody = Encoding.UTF8.GetBytes(messageValue);
 
-            ServiceBusMessage message = new ServiceBusMessage(messageBody);
+            var message = new ServiceBusMessage(messageBody);
 
             await sender.SendMessageAsync(message).ConfigureAwait(false);
             await sender.SendMessageAsync(message).ConfigureAwait(false);
@@ -343,11 +343,11 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
             string name = "Name";
 
             var previousStream = new MemoryStream();
-            PipelineContext context = new PipelineContext();
+            var context = new PipelineContext();
             context.Items.Add(PipelineContextConstants.INPUT_STREAM, previousStream);
 
             string messageValue = "Are you there?";
-            Mock<IPipelineRequest> mockPipelineRequest = new Mock<IPipelineRequest>();
+            var mockPipelineRequest = new Mock<IPipelineRequest>();
             mockPipelineRequest.Setup(x => x.InvokeAsync(context))
                                 .Callback(() =>
                                 {
@@ -379,7 +379,7 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
 
             byte[] messageBody = Encoding.UTF8.GetBytes(messageValue);
 
-            ServiceBusMessage message = new ServiceBusMessage(messageBody);
+            var message = new ServiceBusMessage(messageBody);
             message.ApplicationProperties.Add("KeyId", keyId);
             message.ApplicationProperties.Add("Name", name);
 
@@ -414,12 +414,12 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
             Guid correlationid = Guid.NewGuid();
 
             var previousStream = new MemoryStream();
-            PipelineContext context = new PipelineContext();
+            var context = new PipelineContext();
             context.Items.Add(PipelineContextConstants.INPUT_STREAM, previousStream);
             context.Items.Add(MessagingConstants.CORRELATION_ID, correlationid);
 
             string messageValue = "Are you there?";
-            Mock<IPipelineRequest> mockPipelineRequest = new Mock<IPipelineRequest>();
+            var mockPipelineRequest = new Mock<IPipelineRequest>();
             mockPipelineRequest.Setup(x => x.InvokeAsync(context))
                                 .Callback(() => 
                                 {
@@ -452,7 +452,7 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
 
             byte[] messageBody = Encoding.UTF8.GetBytes(messageValue);
 
-            ServiceBusMessage message = new ServiceBusMessage(messageBody);
+            var message = new ServiceBusMessage(messageBody);
             message.ApplicationProperties.Add("KeyId", keyId);
             message.ApplicationProperties.Add("Name", name);
 
@@ -484,13 +484,13 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
             // arrange
             ILogger<ReadMessageFromAzureStep> logger = null;
 
-            PipelineContext context = new PipelineContext();
+            var context = new PipelineContext();
 
-            Mock<IPipelineRequest> mockPipelineRequest = new Mock<IPipelineRequest>();
+            var mockPipelineRequest = new Mock<IPipelineRequest>();
             mockPipelineRequest.Setup(x => x.InvokeAsync(context)).Returns(Task.CompletedTask);
             var next = mockPipelineRequest.Object;
 
-            ReadMessageFromAzureOptions options = new ReadMessageFromAzureOptions();
+            var options = new ReadMessageFromAzureOptions();
             const string paramName = nameof(logger);
 
             // act
@@ -507,11 +507,11 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
             // arrange
             ILogger<ReadMessageFromAzureStep> logger = new Mock<ILogger<ReadMessageFromAzureStep>>().Object;
 
-            PipelineContext context = new PipelineContext();
+            var context = new PipelineContext();
 
             IPipelineRequest next = null;
 
-            ReadMessageFromAzureOptions options = new ReadMessageFromAzureOptions();
+            var options = new ReadMessageFromAzureOptions();
             const string paramName = nameof(next);
 
             // act
@@ -528,9 +528,9 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
             // arrange
             ILogger<ReadMessageFromAzureStep> logger = new Mock<ILogger<ReadMessageFromAzureStep>>().Object;
 
-            PipelineContext context = new PipelineContext();
+            var context = new PipelineContext();
 
-            Mock<IPipelineRequest> mockPipelineRequest = new Mock<IPipelineRequest>();
+            var mockPipelineRequest = new Mock<IPipelineRequest>();
             mockPipelineRequest.Setup(x => x.InvokeAsync(context)).Returns(Task.CompletedTask);
             var next = mockPipelineRequest.Object;
 
@@ -551,9 +551,9 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
             // arrange
             ILogger<ReadMessageFromAzureStep> logger = new Mock<ILogger<ReadMessageFromAzureStep>>().Object;
 
-            PipelineContext context = new PipelineContext();
+            var context = new PipelineContext();
 
-            Mock<IPipelineRequest> mockPipelineRequest = new Mock<IPipelineRequest>();
+            var mockPipelineRequest = new Mock<IPipelineRequest>();
             mockPipelineRequest.Setup(x => x.InvokeAsync(context))
                                 .Returns(Task.CompletedTask);
 

--- a/Steps/Azure/ServiceBus/test/ReadMessageFromAzureStepTests.cs
+++ b/Steps/Azure/ServiceBus/test/ReadMessageFromAzureStepTests.cs
@@ -354,8 +354,8 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
                                     // assert
                                     using (var reader = new StreamReader(context.Items[PipelineContextConstants.INPUT_STREAM] as Stream))
                                     {
-                                        Assert.AreEqual(keyId, context.Items["KeyId"]);
-                                        Assert.AreEqual(name, context.Items["Name"]);
+                                        Assert.AreEqual(keyId, context.Items["MSG_KeyId"]);
+                                        Assert.AreEqual(name, context.Items["MSG_Name"]);
                                         Assert.AreEqual(messageValue, reader.ReadToEnd());
                                     }
 
@@ -426,8 +426,8 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
                                     // assert
                                     using (var reader = new StreamReader(context.Items[PipelineContextConstants.INPUT_STREAM] as Stream))
                                     {
-                                        Assert.AreEqual(keyId, context.Items["KeyId"]);
-                                        Assert.AreEqual(name, context.Items["Name"]);
+                                        Assert.AreEqual(keyId, context.Items["CHANGED_KeyId"]);
+                                        Assert.AreEqual(name, context.Items["CHANGED_Name"]);
                                         Assert.AreEqual(messageValue, reader.ReadToEnd());
                                     }
                                     
@@ -440,6 +440,7 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
             {
                 AzureServiceBusConnectionString = Tests.TestConstants.AzureServiceBusConnectionString,
                 EntityPath = $"{Tests.TestConstants.ReadFromTopicName}/{Tests.TestConstants.SubscriptionName}",
+                MessageContextItemsPrefix = "CHANGED_",
                 TimeToWaitBetweenMessageChecks = new TimeSpan(0, 0, 0, 0, 50),
                 TimeToWaitForNewMessage = new TimeSpan(0, 0, 1, 0, 0)
             };

--- a/Steps/Azure/ServiceBus/test/ReadMessageFromAzureStepTests.cs
+++ b/Steps/Azure/ServiceBus/test/ReadMessageFromAzureStepTests.cs
@@ -1,7 +1,7 @@
 // <copyright file="ReadMessageFromAzureStepTests.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2019-2020 Chris Trout
+// Copyright(c) 2019-2022 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Steps/Azure/ServiceBus/test/ReadMessageFromStepOptionsTests.cs
+++ b/Steps/Azure/ServiceBus/test/ReadMessageFromStepOptionsTests.cs
@@ -1,7 +1,7 @@
 ﻿// <copyright file="ReadMessageFromAzureStepTests.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2019-2020 Chris Trout
+// Copyright(c) 2019-2022 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Steps/Azure/ServiceBus/test/ReadMessageFromStepOptionsTests.cs
+++ b/Steps/Azure/ServiceBus/test/ReadMessageFromStepOptionsTests.cs
@@ -36,14 +36,13 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
         public void Constructs_ReadMessageFromStepOptions_Successfully()
         {
             // arrange
-            List<string> applicationProperties = new List<string>() { "UserId", "MessageId" };
             string azureServiceBusConnectionString = "ConnectionString";
             int batchSize = 100;
             int deliveryAttemptsBeforeDeadLetter = 2;
             string entityPath = "topic/subscription";
             string messagePrefix = "CHANGED_";
-            TimeSpan timeToWaitBetweenMessageChecks = new TimeSpan(0, 0, 1);
-            TimeSpan timeToWaitForNewMessage = new TimeSpan(0, 1, 0);
+            var timeToWaitBetweenMessageChecks = new TimeSpan(0, 0, 1);
+            var timeToWaitForNewMessage = new TimeSpan(0, 1, 0);
 
 
             // act

--- a/Steps/Azure/ServiceBus/test/ReadMessageFromStepOptionsTests.cs
+++ b/Steps/Azure/ServiceBus/test/ReadMessageFromStepOptionsTests.cs
@@ -41,28 +41,30 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
             int batchSize = 100;
             int deliveryAttemptsBeforeDeadLetter = 2;
             string entityPath = "topic/subscription";
+            string messagePrefix = "CHANGED_";
             TimeSpan timeToWaitBetweenMessageChecks = new TimeSpan(0, 0, 1);
             TimeSpan timeToWaitForNewMessage = new TimeSpan(0, 1, 0);
+
 
             // act
             var result = new ReadMessageFromAzureOptions
             {
-                ApplicationProperties = applicationProperties,
                 AzureServiceBusConnectionString = azureServiceBusConnectionString,
                 BatchSize = batchSize,
                 DeliveryAttemptsBeforeDeadLetter = deliveryAttemptsBeforeDeadLetter,
                 EntityPath = entityPath,
+                MessageContextItemsPrefix = messagePrefix,
                 TimeToWaitBetweenMessageChecks = timeToWaitBetweenMessageChecks,
                 TimeToWaitForNewMessage = timeToWaitForNewMessage
             };
 
             // assert
             Assert.IsNotNull(result);
-            Assert.AreEqual(applicationProperties, result.ApplicationProperties);
             Assert.AreEqual(azureServiceBusConnectionString, result.AzureServiceBusConnectionString);
             Assert.AreEqual(batchSize, result.BatchSize);
             Assert.AreEqual(deliveryAttemptsBeforeDeadLetter, result.DeliveryAttemptsBeforeDeadLetter);
             Assert.AreEqual(entityPath, result.EntityPath);
+            Assert.AreEqual(messagePrefix, result.MessageContextItemsPrefix);
             Assert.AreEqual(timeToWaitBetweenMessageChecks, result.TimeToWaitBetweenMessageChecks);
             Assert.AreEqual(timeToWaitForNewMessage, result.TimeToWaitForNewMessage);
 

--- a/Steps/Azure/ServiceBus/test/ServiceBusReadEntityTests.cs
+++ b/Steps/Azure/ServiceBus/test/ServiceBusReadEntityTests.cs
@@ -1,7 +1,7 @@
 ﻿// <copyright file="ReadMessageFromAzureStepTests.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2019-2020 Chris Trout
+// Copyright(c) 2019-2022 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Steps/Azure/ServiceBus/test/ServiceBusReadEntityTests.cs
+++ b/Steps/Azure/ServiceBus/test/ServiceBusReadEntityTests.cs
@@ -70,7 +70,7 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
         }
 
         [TestMethod]
-        public void Constructs_ServiceBusReadEntity_With_Unknqwn_Successfully()
+        public void Constructs_ServiceBusReadEntity_With_Unknown_EntityPath_Successfully()
         {
             // arrange
             string entityPath = "unknown/topic/subscription";
@@ -90,6 +90,34 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
         {
             // arrange
             string entityPath = null;
+            var paramName = nameof(entityPath);
+            // act
+            var result = Assert.ThrowsException<ArgumentNullException>(() => new ServiceBusReadEntity(entityPath));
+
+            // assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(paramName, result.ParamName);
+        }
+
+        [TestMethod]
+        public void Throws_ArgumentNullException_From_Constructor_When_EntityPath_Is_Empty()
+        {
+            // arrange
+            string entityPath = string.Empty;
+            var paramName = nameof(entityPath);
+            // act
+            var result = Assert.ThrowsException<ArgumentNullException>(() => new ServiceBusReadEntity(entityPath));
+
+            // assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(paramName, result.ParamName);
+        }
+
+        [TestMethod]
+        public void Throws_ArgumentNullException_From_Constructor_When_EntityPath_Is_Whitespace()
+        {
+            // arrange
+            string entityPath = "\r\n\t";
             var paramName = nameof(entityPath);
             // act
             var result = Assert.ThrowsException<ArgumentNullException>(() => new ServiceBusReadEntity(entityPath));

--- a/Steps/Azure/ServiceBus/test/TestOverrideEvaluateCancellationTokenStep.cs
+++ b/Steps/Azure/ServiceBus/test/TestOverrideEvaluateCancellationTokenStep.cs
@@ -1,7 +1,7 @@
 ﻿// <copyright file="TestOverrideEvaluateCancellationTokenStep.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2019-2020 Chris Trout
+// Copyright(c) 2019-2022 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Steps/Azure/ServiceBus/test/TestOverrideReadMessageFromAzureDisposeStep.cs
+++ b/Steps/Azure/ServiceBus/test/TestOverrideReadMessageFromAzureDisposeStep.cs
@@ -1,0 +1,41 @@
+﻿// <copyright file="TestOverrideReadMessageFromAzureDisposeStep .cs" company="Chris Trout">
+// MIT License
+//
+// Copyright(c) 2022 Chris Trout
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+
+
+namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
+{
+    using Microsoft.Extensions.Logging;
+
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage()]
+    public class TestOverrideReadMessageFromAzureDisposeStep : ReadMessageFromAzureStep
+    {
+        public TestOverrideReadMessageFromAzureDisposeStep(ILogger<ReadMessageFromAzureStep> logger, ReadMessageFromAzureOptions options, IPipelineRequest next) 
+            : base(logger, options, next)
+        {
+            this.ServiceBusClient = null;
+            this.ServiceBusReceiver = null;
+        }
+    }
+}

--- a/Steps/Azure/ServiceBus/test/TestOverrideWriteMessageToAzureDisposeStep.cs
+++ b/Steps/Azure/ServiceBus/test/TestOverrideWriteMessageToAzureDisposeStep.cs
@@ -1,7 +1,7 @@
-﻿// <copyright file="TestOverrideEvaluateCancellationTokenStep.cs" company="Chris Trout">
+﻿// <copyright file="TestOverrideWriteMessageToAzureDisposeStep .cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2019-2020 Chris Trout
+// Copyright(c) 2022 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -26,28 +26,16 @@
 
 namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
 {
-    using global::Azure.Messaging.ServiceBus;
     using Microsoft.Extensions.Logging;
-    using System.Threading;
-    using System.Threading.Tasks;
 
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage()]
-    public class TestOverrideEvaluateCancellationTokenStep : ReadMessageFromAzureStep
+    public class TestOverrideWriteMessageToAzureDisposeStep : WriteMessageToAzureStep
     {
-        public TestOverrideEvaluateCancellationTokenStep(ILogger<ReadMessageFromAzureStep> logger, ReadMessageFromAzureOptions options, IPipelineRequest next) 
+        public TestOverrideWriteMessageToAzureDisposeStep(ILogger<WriteMessageToAzureStep> logger, WriteMessageToAzureOptions options, IPipelineRequest next)
             : base(logger, options, next)
         {
-            // no op
-        }
-
-        protected override Task<bool> EvaluateCancellationOfMessageAsync(IPipelineContext context, ServiceBusReceivedMessage message, ServiceBusReceiver serviceBusReceiver, params CancellationToken[] tokens)
-        {
-            var tokenSource = new CancellationTokenSource();
-            tokenSource.Cancel();
-            context.CancellationToken = tokenSource.Token;
-
-            var tempReceiver = this.ServiceBusClient.CreateReceiver(this.Options.ReadEntity.QueueName);
-            return base.EvaluateCancellationOfMessageAsync(context, message,  tempReceiver, context.CancellationToken);
+            this.ServiceBusClient = null;
+            this.ServiceBusSender = null;
         }
     }
 }

--- a/Steps/Azure/ServiceBus/test/WriteMessageToAzureTopicStepTests.cs
+++ b/Steps/Azure/ServiceBus/test/WriteMessageToAzureTopicStepTests.cs
@@ -62,7 +62,7 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
         }
 
         [TestMethod]
-        public async void Disposes_WriteMessageToAzureStep_Successfully()
+        public async Task Disposes_WriteMessageToAzureStep_Successfully()
         {
             // arrange
             ILogger<WriteMessageToAzureStep> logger = new Mock<ILogger<WriteMessageToAzureStep>>().Object;
@@ -81,7 +81,6 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
             // assert
             // No exception means that everything went well.
             Assert.IsTrue(true);
-
         }
 
         [TestMethod]

--- a/Steps/Azure/ServiceBus/test/WriteMessageToAzureTopicStepTests.cs
+++ b/Steps/Azure/ServiceBus/test/WriteMessageToAzureTopicStepTests.cs
@@ -1,7 +1,7 @@
 // <copyright file="WriteMessageToAzureStepTests.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2019-2020 Chris Trout
+// Copyright(c) 2019-2022 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Steps/Azure/ServiceBus/test/WriteMessageToAzureTopicStepTests.cs
+++ b/Steps/Azure/ServiceBus/test/WriteMessageToAzureTopicStepTests.cs
@@ -31,11 +31,8 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
     using MyTrout.Pipelines;
     using MyTrout.Pipelines.Core;
     using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
-    using System.Globalization;
     using System.IO;
-    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -65,6 +62,27 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
         }
 
         [TestMethod]
+        public async void Disposes_WriteMessageToAzureStep_Successfully()
+        {
+            // arrange
+            ILogger<WriteMessageToAzureStep> logger = new Mock<ILogger<WriteMessageToAzureStep>>().Object;
+            IPipelineRequest next = new Mock<IPipelineRequest>().Object;
+            var options = new WriteMessageToAzureOptions()
+            {
+                AzureServiceBusConnectionString = Tests.TestConstants.AzureServiceBusConnectionString,
+                QueueOrTopicName = Tests.TestConstants.WriteToTopicName
+            };
+
+            var sut = new TestOverrideWriteMessageToAzureDisposeStep(logger, options, next);
+
+            // act
+            await sut.DisposeAsync();
+
+            // assert
+            Assert.IsNull(sut);
+        }
+
+        [TestMethod]
         public async Task Returns_PipelineContext_From_InvokeAsync_Using_FileStream()
         {
             // arrange
@@ -79,17 +97,16 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
             var context = new PipelineContext();
             context.Items.Add(PipelineContextConstants.OUTPUT_STREAM, inputStream);
             context.Items.Add(MessagingConstants.CORRELATION_ID, Guid.NewGuid());
-            context.Items.Add("id", id);
-            context.Items.Add("name", name);
-            context.Items.Add("isActive", isActive);
+            context.Items.Add("MSG_id", id);
+            context.Items.Add("MSG_name", name);
+            context.Items.Add("MSG_isActive", isActive);
 
-            Mock<IPipelineRequest> mockPipelineRequest = new Mock<IPipelineRequest>();
+            var mockPipelineRequest = new Mock<IPipelineRequest>();
             mockPipelineRequest.Setup(x => x.InvokeAsync(context)).Returns(Task.CompletedTask);
             IPipelineRequest next = mockPipelineRequest.Object;
 
             var options = new WriteMessageToAzureOptions()
             {
-                ApplicationProperties = new List<string>() { "id", "name", "isActive" },
                 AzureServiceBusConnectionString = Tests.TestConstants.AzureServiceBusConnectionString,
                 QueueOrTopicName = Tests.TestConstants.WriteToTopicName
             };
@@ -145,17 +162,16 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
 
             var context = new PipelineContext();
             context.Items.Add(PipelineContextConstants.OUTPUT_STREAM, inputStream);
-            context.Items.Add("id", id);
-            context.Items.Add("name", name);
-            context.Items.Add("isActive", isActive);
+            context.Items.Add("MSG_id", id);
+            context.Items.Add("MSG_name", name);
+            context.Items.Add("MSG_isActive", isActive);
 
-            Mock<IPipelineRequest> mockPipelineRequest = new Mock<IPipelineRequest>();
+            var mockPipelineRequest = new Mock<IPipelineRequest>();
             mockPipelineRequest.Setup(x => x.InvokeAsync(context)).Returns(Task.CompletedTask);
             IPipelineRequest next = mockPipelineRequest.Object;
 
             var options = new WriteMessageToAzureOptions()
             {
-                ApplicationProperties = new List<string>() { "description" },
                 AzureServiceBusConnectionString = Tests.TestConstants.AzureServiceBusConnectionString,
                 QueueOrTopicName = Tests.TestConstants.WriteToTopicName
             };
@@ -257,7 +273,7 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
             // arrange
             ILogger<WriteMessageToAzureStep> logger = null;
             IPipelineRequest next = new Mock<IPipelineRequest>().Object;
-            WriteMessageToAzureOptions options = new WriteMessageToAzureOptions();
+            var options = new WriteMessageToAzureOptions();
             const string paramName = nameof(logger);
 
             // act
@@ -274,7 +290,7 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
             // arrange
             ILogger<WriteMessageToAzureStep> logger = new Mock<ILogger<WriteMessageToAzureStep>>().Object;
             IPipelineRequest next = null;
-            WriteMessageToAzureOptions options = new WriteMessageToAzureOptions();
+            var options = new WriteMessageToAzureOptions();
             const string paramName = nameof(next);
 
             // act

--- a/Steps/Azure/ServiceBus/test/WriteMessageToAzureTopicStepTests.cs
+++ b/Steps/Azure/ServiceBus/test/WriteMessageToAzureTopicStepTests.cs
@@ -79,7 +79,9 @@ namespace MyTrout.Pipelines.Steps.Azure.ServiceBus.Tests
             await sut.DisposeAsync();
 
             // assert
-            Assert.IsNull(sut);
+            // No exception means that everything went well.
+            Assert.IsTrue(true);
+
         }
 
         [TestMethod]


### PR DESCRIPTION
 - (BREAKING CHANGE) - ReadMessageFromAzureStep will always copy all ApplicationProperties values from a message into PipelineContext.Items with a prefix provided by ReadMessageFromAzureOptions.
 - (BREAKING CHANGE) - ReadMessageFromAzureOptions.ApplicationProperties has been removed permanently.
 - (BREAKING CHANGE) - ReadMessageFromAzureStep.EvaluateCancellationOfMessageAsync method was refactored to allow integration testing to use a change in this method instead of a protected setter on the ServiceBusReceiver property.
 - (BREAKING CHANGE) - ReadMessageFromAzureStep.ServiceBusReceiver is no longer a protected setter; it is read-only after construction.
 - (BREAKING CHANGE) - WriteMessageToAzureOptions.ApplicationProperties has been removed permanently.
 - (BREAKING CHANGE) - WriteMessageToAzureStep will always copy all PipelineContext.Items values prefixed with WriteMessageToAzureOptions.MessageContextItemsPrefix to the message being sent.
 - Correction of StyleCop and other analyzers to ensure consistency across projects.