### PR TITLE
- Change from suppressions to null-forgiving operators to handle know…

### DIFF
--- a/.github/workflows/build-pipelines-steps-io-files.yaml
+++ b/.github/workflows/build-pipelines-steps-io-files.yaml
@@ -33,7 +33,7 @@ jobs:
         SOLUTION_NAME: 'MyTrout.Pipelines.Steps.IO.Files.sln'
         
         # This value should change on each deployable version of this solution.
-        PROJECT_VERSION: '3.1.0'
+        PROJECT_VERSION: '3.2.0'
         
     steps:
       - name: Checkout the Source
@@ -84,17 +84,18 @@ jobs:
         run: dotnet sonarscanner end /d:sonar.login=${{ secrets.MYTROUT_SONARQUBE_API_KEY }}      
         if: ${{ github.actor != 'dependabot[bot]' }}
 
-      #- name: Upload nupkg
-      #  uses: actions/upload-artifact@v2
-      #  with:
-      #    name: nupkg
-      #    path: ${{ env.WORKING_DIRECTORY }}/**/bin/Release/*.nupkg
-      #  if: "github.ref == 'refs/heads/master' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
+      - name: Upload nupkg
+        uses: actions/upload-artifact@v3
+        with:
+          name: nupkg
+          path: ${{ env.WORKING_DIRECTORY }}/**/bin/Release/*.nupkg
+          if-no-files-found: 
+        if: "github.ref == 'refs/heads/master' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
         
-      #- name: Publish the package to nuget.org.
-      #  run: dotnet nuget push "${{ env.WORKING_DIRECTORY }}/src/bin/Release/*.nupkg" --api-key ${{ secrets.MYTROUT_NUGET_API_KEY }} --source "https://api.nuget.org/v3/index.json"
-      #  if: "github.ref == 'refs/heads/master' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
+      - name: Publish the package to nuget.org.
+        run: dotnet nuget push "${{ env.WORKING_DIRECTORY }}/src/bin/Release/*.nupkg" --api-key ${{ secrets.MYTROUT_NUGET_API_KEY }} --source "https://api.nuget.org/v3/index.json"
+        if: "github.ref == 'refs/heads/master' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
 
-      #- name: Publish the package to GitHub.
-      #  run: dotnet nuget push "${{ env.WORKING_DIRECTORY }}/src/bin/Release/*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/mytrout/index.json"
-      #  if: "github.ref == 'refs/heads/master' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
+      - name: Publish the package to GitHub.
+        run: dotnet nuget push "${{ env.WORKING_DIRECTORY }}/src/bin/Release/*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/mytrout/index.json"
+        if: "github.ref == 'refs/heads/master' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"

--- a/Steps/IO/Files/changelog.md
+++ b/Steps/IO/Files/changelog.md
@@ -1,5 +1,15 @@
 # MyTrout.Pipelines.Steps.IO.Files Change Log
 
+## 3.2.0
+- Change from suppressions to null-forgiving operators to handle known false positive null warnings.
+- Add AppendStreamToFileStep and ~Options to allow a stream to be appended to an new or existing file.
+- Change the underlying base type for ReadStreamFromFileSystemStep to use the AbstractCachingPipelineStep<TService, TOptions> instead of implementing caching in this class.
+- Uncomment the nuget publishing to allow version 3.2.0 to be published.
+- Suppress SA1636 to allow for variation in the copyright headers for 2022 and range from 2019-2022.
+- Add if-no-files-found to the nuget publish step in build.
+- Bump actions/upload-artifact from 2 to 3.
+- Uncomment the local Github artifact publish, nuget.org publish, and local Github nuget publish to allow these actions to run again.
+
 ## 3.1.0
  - Upgrade to .NET 6.0 while maintaining 5.0 support.
  - Update Resources.tt to reflect .NET 6.0 instead of .NET 5.0

--- a/Steps/IO/Files/src/AppendStreamToFileOptions.cs
+++ b/Steps/IO/Files/src/AppendStreamToFileOptions.cs
@@ -1,0 +1,47 @@
+﻿// <copyright file="AppendStreamToFileOptions.cs" company="Chris Trout">
+// MIT License
+//
+// Copyright(c) 2022 Chris Trout
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+namespace MyTrout.Pipelines.Steps.IO.Files
+{
+    /*
+     *  IMPORTANT NOTE: As long as this class only contains compiler-generated functionality, it requires no unit tests.
+     */
+
+    /// <summary>
+    /// Provides caller-configurable options to change the behavior of <see cref="AppendStreamToFileStep"/>.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public class AppendStreamToFileOptions
+    {
+        /// <summary>
+        /// Gets or sets the timing of when the <see cref="AppendStreamToFileStep"/> will be executed.
+        /// </summary>
+        public ExecutionTimings ExecutionTimings { get; set; } = ExecutionTimings.After;
+
+        /// <summary>
+        /// Gets or sets the base directory to which the application should write the file.
+        /// </summary>
+        public string AppendFileBaseDirectory { get; set; } = string.Empty;
+    }
+}

--- a/Steps/IO/Files/src/MoveFileStep.cs
+++ b/Steps/IO/Files/src/MoveFileStep.cs
@@ -73,9 +73,7 @@ namespace MyTrout.Pipelines.Steps.IO.Files
             context.AssertFileNameParameterIsValid(FileConstants.SOURCE_FILE, options.MoveSourceFileBaseDirectory);
             context.AssertFileNameParameterIsValid(FileConstants.TARGET_FILE, options.MoveTargetFileBaseDirectory);
 
-#pragma warning disable CS8600, CS8604 // AssertFileNameParameterIsValid guarantees that SOURCE_FILE and TARGET_FILE is not null.
-
-            string sourceFile = context.Items[FileConstants.SOURCE_FILE] as string;
+            string sourceFile = (context.Items[FileConstants.SOURCE_FILE] as string)!;
 
             sourceFile = sourceFile.GetFullyQualifiedPath(options.MoveSourceFileBaseDirectory);
 
@@ -84,7 +82,7 @@ namespace MyTrout.Pipelines.Steps.IO.Files
                 throw new InvalidOperationException(Resources.FILE_DOES_NOT_EXIST(CultureInfo.CurrentCulture, sourceFile));
             }
 
-            string targetFile = context.Items[FileConstants.TARGET_FILE] as string;
+            string targetFile = (context.Items[FileConstants.TARGET_FILE] as string)!;
             targetFile = targetFile.GetFullyQualifiedPath(options.MoveTargetFileBaseDirectory);
 
             if (File.Exists(targetFile))
@@ -96,12 +94,10 @@ namespace MyTrout.Pipelines.Steps.IO.Files
 
             if (!Directory.Exists(workingPath))
             {
-                Directory.CreateDirectory(workingPath);
+                Directory.CreateDirectory(workingPath!);
             }
 
             File.Move(sourceFile, targetFile);
-
-#pragma warning restore CS8600, CS8604
 
             return Task.CompletedTask;
         }

--- a/Steps/IO/Files/src/MyTrout.Pipelines.Steps.IO.Files.csproj
+++ b/Steps/IO/Files/src/MyTrout.Pipelines.Steps.IO.Files.csproj
@@ -4,13 +4,13 @@
     <TargetFrameworks>net6.0;net5.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Chris Trout</Authors>
-    <Copyright>Copyright 2019-2021 Chris Trout. All Rights Reserved.</Copyright>
+    <Copyright>Copyright 2019-2022 Chris Trout. All Rights Reserved.</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Version>0.5.0-beta</Version>
     <NeutralLanguage>en-US</NeutralLanguage>
     <AssemblyVersion>0.1.0.0</AssemblyVersion>
     <FileVersion>0.51.0.0</FileVersion>
-    <Description>Provides Pipeline steps to read, write, delete, and move files on the file system.</Description>
+    <Description>Provides Pipeline steps to append data, read, write, delete, and move files on the file system.</Description>
     <PackageProjectUrl>https://github.com/mytrout/Pipelines/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/mytrout/Pipelines.git</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
@@ -23,7 +23,7 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <ErrorReport>prompt</ErrorReport>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
-    <NoWarn>1701;1702;IDE0063;SA1413;S4792</NoWarn>
+    <NoWarn>1701;1702;IDE0063;SA1413;SA1636;S4792</NoWarn>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <IncludeSymbols>true</IncludeSymbols>

--- a/Steps/IO/Files/src/ReadStreamFromFileSystemStep.cs
+++ b/Steps/IO/Files/src/ReadStreamFromFileSystemStep.cs
@@ -1,7 +1,7 @@
 ﻿// <copyright file="ReadStreamFromFileSystemStep.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2019-2020 Chris Trout
+// Copyright(c) 2019-2022 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,7 @@ namespace MyTrout.Pipelines.Steps.IO.Files
 {
     using Microsoft.Extensions.Logging;
     using System;
+    using System.Collections.Generic;
     using System.Globalization;
     using System.IO;
     using System.Threading.Tasks;
@@ -33,7 +34,7 @@ namespace MyTrout.Pipelines.Steps.IO.Files
     /// <summary>
     /// Reads a file from the File System and puts it into the <see cref="MyTrout.Pipelines.Core.PipelineContext" /> as an input <see cref="Stream"/>.
     /// </summary>
-    public class ReadStreamFromFileSystemStep : AbstractPipelineStep<ReadStreamFromFileSystemStep, ReadStreamFromFileSystemOptions>
+    public class ReadStreamFromFileSystemStep : AbstractCachingPipelineStep<ReadStreamFromFileSystemStep, ReadStreamFromFileSystemOptions>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ReadStreamFromFileSystemStep" /> class with the specified parameters.
@@ -47,19 +48,20 @@ namespace MyTrout.Pipelines.Steps.IO.Files
             // no op
         }
 
+        /// <inheritdoc />
+        public override IEnumerable<string> CachedItemNames => new List<string>() { PipelineContextConstants.INPUT_STREAM };
+
         /// <summary>
-        /// Writes a file to the configured file system.
+        /// Reads a file from the configured file system and puts it into the <see cref="MyTrout.Pipelines.Core.PipelineContext"/> named <see cref="PipelineContextConstants.INPUT_STREAM" />.
         /// </summary>
         /// <param name="context">The pipeline context.</param>
         /// <returns>A completed <see cref="Task" />.</returns>
         /// <remarks><paramref name="context"/> is guaranteed to not be -<see langword="null" /> by the base class.</remarks>
-        protected override async Task InvokeCoreAsync(IPipelineContext context)
+        protected override async Task InvokeCachedCoreAsync(IPipelineContext context)
         {
             context.AssertFileNameParameterIsValid(FileConstants.SOURCE_FILE, this.Options.ReadFileBaseDirectory);
 
-#pragma warning disable CS8600, CS8604 // AssertFileNameParameterIsValid guarantees that workingFile value is not null.
-
-            string workingFile = context.Items[FileConstants.SOURCE_FILE] as string;
+            string workingFile = (context.Items[FileConstants.SOURCE_FILE] as string)!;
 
             workingFile = workingFile.GetFullyQualifiedPath(this.Options.ReadFileBaseDirectory);
 
@@ -68,35 +70,20 @@ namespace MyTrout.Pipelines.Steps.IO.Files
                 throw new InvalidOperationException(Resources.FILE_DOES_NOT_EXIST(CultureInfo.CurrentCulture, workingFile));
             }
 
-            if (context.Items.TryGetValue(PipelineContextConstants.INPUT_STREAM, out object previous))
+            using (var inputStream = File.OpenRead(workingFile))
             {
-                context.Items.Remove(PipelineContextConstants.INPUT_STREAM);
-            }
+                context.Items.Add(PipelineContextConstants.INPUT_STREAM, inputStream);
 
-            try
-            {
-                using (var inputStream = File.OpenRead(workingFile))
+                try
                 {
-                    context.Items.Add(PipelineContextConstants.INPUT_STREAM, inputStream);
-
                     await this.Next.InvokeAsync(context).ConfigureAwait(false);
-
-                    context.Items.Remove(PipelineContextConstants.INPUT_STREAM);
                 }
-            }
-            finally
-            {
-                if (context.Items.ContainsKey(PipelineContextConstants.INPUT_STREAM))
+                finally
                 {
+                    // Guarantees that INPUT_STREAM is removed prior to returning from this function, even when an exception is thrown in this.Next.InvokeAsync().
                     context.Items.Remove(PipelineContextConstants.INPUT_STREAM);
-                }
-
-                if (previous != null)
-                {
-                    context.Items.Add(PipelineContextConstants.INPUT_STREAM, previous);
                 }
             }
         }
-#pragma warning restore CS8600, CS8604
     }
 }

--- a/Steps/IO/Files/src/WriteStreamToFileSystemStep.cs
+++ b/Steps/IO/Files/src/WriteStreamToFileSystemStep.cs
@@ -48,7 +48,7 @@ namespace MyTrout.Pipelines.Steps.IO.Files
         }
 
         /// <summary>
-        /// Reads a file from the configured file system location.
+        /// Writes a file to the configured file system location.
         /// </summary>
         /// <param name="context">The pipeline context.</param>
         /// <returns>A completed <see cref="Task" />.</returns>
@@ -73,9 +73,7 @@ namespace MyTrout.Pipelines.Steps.IO.Files
             context.AssertFileNameParameterIsValid(FileConstants.TARGET_FILE, options.WriteFileBaseDirectory);
             context.AssertValueIsValid<Stream>(PipelineContextConstants.OUTPUT_STREAM);
 
-#pragma warning disable CS8600, CS8602, CS8604 // Assert~ methods guarantee that workingFile and workStream are not null.
-
-            string workingFile = context.Items[FileConstants.TARGET_FILE] as string;
+            string workingFile = (context.Items[FileConstants.TARGET_FILE] as string)!;
 
             workingFile = workingFile.GetFullyQualifiedPath(options.WriteFileBaseDirectory);
 
@@ -84,13 +82,12 @@ namespace MyTrout.Pipelines.Steps.IO.Files
                 throw new InvalidOperationException(Resources.FILE_ALREADY_EXISTS(CultureInfo.CurrentCulture, workingFile));
             }
 
-            Stream workingStream = context.Items[PipelineContextConstants.OUTPUT_STREAM] as Stream;
+            Stream workingStream = (context.Items[PipelineContextConstants.OUTPUT_STREAM] as Stream)!;
 
             using (FileStream outputStream = File.OpenWrite(workingFile))
             {
                 await workingStream.CopyToAsync(outputStream).ConfigureAwait(false);
             }
-#pragma warning restore CS8600, CS8602, CS8604
         }
     }
 }

--- a/Steps/IO/Files/test/AppendStreamToFileStepTests.cs
+++ b/Steps/IO/Files/test/AppendStreamToFileStepTests.cs
@@ -1,0 +1,439 @@
+// <copyright file="AppendStreamToFileStepTests.cs" company="Chris Trout">
+// MIT License
+//
+// Copyright(c) 2022 Chris Trout
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+namespace MyTrout.Pipelines.Steps.IO.Files.Tests
+{
+    using Microsoft.Extensions.Logging;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using MyTrout.Pipelines.Core;
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Globalization;
+    using System.IO;
+    using System.Reflection;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    [ExcludeFromCodeCoverage]
+    [TestClass]
+    public class AppendStreamToFileStepTests
+    {
+        [TestMethod]
+        public async Task Constructs_AppendStreamToFileTests_Successfully()
+        {
+            // arrange
+            string outputFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}{Path.DirectorySeparatorChar}";
+
+            var logger = new Mock<ILogger<AppendStreamToFileStep>>().Object;
+            var next = new Mock<IPipelineRequest>().Object;
+            var options = new AppendStreamToFileOptions()
+            {
+                AppendFileBaseDirectory = outputFilePath
+            };
+
+            // act
+            var result = new AppendStreamToFileStep(logger, next, options);
+
+            // assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(logger, result.Logger);
+            Assert.AreEqual(options, result.Options);
+
+            // cleanup
+            await result.DisposeAsync().ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task Appends_Data_To_File_From_InvokeAsync_When_ExecutionTimings_Before_Is_Configured()
+        {
+            // arrange
+            string outputFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}{Path.DirectorySeparatorChar}";
+            string contents = "What is the text here?";
+            byte[] body = Encoding.UTF8.GetBytes(contents);
+
+            string fileName = $"{Guid.NewGuid()}.txt";
+
+            string fullPathAndFileName = outputFilePath + fileName;
+
+            using (var stream = new MemoryStream(body))
+            {
+                var context = new PipelineContext();
+                context.Items.Add(FileConstants.TARGET_FILE, fileName);
+                context.Items.Add(PipelineContextConstants.OUTPUT_STREAM, stream);
+
+                var logger = new Mock<ILogger<AppendStreamToFileStep>>().Object;
+
+                var mockNext = new Mock<IPipelineRequest>();
+                mockNext.Setup(x => x.InvokeAsync(context))
+                        .Callback(() =>
+                        {
+                            Assert.IsTrue(File.Exists(fullPathAndFileName));
+                            Assert.IsTrue((context.Items[PipelineContextConstants.OUTPUT_STREAM] as Stream).CanRead, "The stream should be open.");
+                            Assert.AreEqual(contents, File.ReadAllText(fullPathAndFileName));
+                        })
+                        .Returns(Task.CompletedTask);
+                var next = mockNext.Object;
+
+                var options = new AppendStreamToFileOptions()
+                {
+                    ExecutionTimings = ExecutionTimings.Before,
+                    AppendFileBaseDirectory = outputFilePath
+                };
+
+                var source = new AppendStreamToFileStep(logger, next, options);
+
+                // act
+                await source.InvokeAsync(context).ConfigureAwait(false);
+
+                // assert
+                Assert.IsTrue(File.Exists(fullPathAndFileName));
+                Assert.IsTrue((context.Items[PipelineContextConstants.OUTPUT_STREAM] as Stream).CanRead, "The stream should be open.");
+                Assert.AreEqual(contents, File.ReadAllText(fullPathAndFileName));
+
+                // cleanup
+                await source.DisposeAsync().ConfigureAwait(false);
+                File.Delete(fullPathAndFileName);
+            }
+        }
+
+        [TestMethod]
+        public async Task Appends_Data_To_File_From_InvokeAsync_When_Target_FileName_Already_Exists()
+        {
+            // arrange
+            string outputFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}{Path.DirectorySeparatorChar}";
+            string contents = "What is the text here?";
+            byte[] body = Encoding.UTF8.GetBytes(contents);
+
+            string fileName = $"{Guid.NewGuid()}.txt";
+
+            string fullPathAndFileName = outputFilePath + fileName;
+            await File.WriteAllBytesAsync(fullPathAndFileName, body).ConfigureAwait(false);
+
+            string expectedContents = $"{contents}{contents}";
+            using (var stream = new MemoryStream(body))
+            {
+                var context = new PipelineContext();
+                context.Items.Add(PipelineContextConstants.OUTPUT_STREAM, stream);
+                context.Items.Add(FileConstants.TARGET_FILE, fullPathAndFileName);
+
+                var logger = new Mock<ILogger<AppendStreamToFileStep>>().Object;
+
+                var mockNext = new Mock<IPipelineRequest>();
+                mockNext.Setup(x => x.InvokeAsync(context)).Returns(Task.CompletedTask);
+                var next = mockNext.Object;
+
+                var options = new AppendStreamToFileOptions()
+                {
+                    AppendFileBaseDirectory = outputFilePath
+                };
+
+                var source = new AppendStreamToFileStep(logger, next, options);
+
+                int errorCount = 0;
+
+                // act
+                await source.InvokeAsync(context).ConfigureAwait(false);
+
+                // assert
+                Assert.AreEqual(errorCount, context.Errors.Count);
+
+                string actualContents = File.ReadAllText(fullPathAndFileName);
+                Assert.AreEqual(expectedContents, actualContents);
+
+                // cleanup
+                File.Delete(fullPathAndFileName);
+                await source.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        [TestMethod]
+        public async Task Appends_Data_To_File_From_InvokeAsync()
+        {
+            // arrange
+            string outputFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}{Path.DirectorySeparatorChar}";
+            string contents = "What is the text here?";
+            byte[] body = Encoding.UTF8.GetBytes(contents);
+
+            string fileName = $"{Guid.NewGuid()}.txt";
+
+            string fullPathAndFileName = outputFilePath + fileName;
+
+            using (var stream = new MemoryStream(body))
+            {
+                var context = new PipelineContext();
+                context.Items.Add(FileConstants.TARGET_FILE, fileName);
+                context.Items.Add(PipelineContextConstants.OUTPUT_STREAM, stream);
+
+                var logger = new Mock<ILogger<AppendStreamToFileStep>>().Object;
+
+                var mockNext = new Mock<IPipelineRequest>();
+                mockNext.Setup(x => x.InvokeAsync(context)).Returns(Task.CompletedTask);
+                var next = mockNext.Object;
+
+                var options = new AppendStreamToFileOptions()
+                {
+                    AppendFileBaseDirectory = outputFilePath
+                };
+
+                var source = new AppendStreamToFileStep(logger, next, options);
+
+                // act
+                await source.InvokeAsync(context).ConfigureAwait(false);
+
+                // assert
+                Assert.IsTrue(File.Exists(fullPathAndFileName));
+                Assert.IsTrue((context.Items[PipelineContextConstants.OUTPUT_STREAM] as Stream).CanRead, "The stream should be open.");
+                Assert.AreEqual(contents, File.ReadAllText(fullPathAndFileName));
+
+                // cleanup
+                await source.DisposeAsync().ConfigureAwait(false);
+                File.Delete(fullPathAndFileName);
+            }
+        }
+
+        [TestMethod]
+        public async Task Returns_PipelineContext_Error_From_InvokeAsync_When_FileName_Is_Not_In_The_Context()
+        {
+            // arrange
+            string outputFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}{Path.DirectorySeparatorChar}";
+            string contents = "What is the text here?";
+            byte[] body = Encoding.UTF8.GetBytes(contents);
+
+            using (var stream = new MemoryStream(body))
+            {
+                var context = new PipelineContext();
+                context.Items.Add(PipelineContextConstants.OUTPUT_STREAM, stream);
+
+                var logger = new Mock<ILogger<AppendStreamToFileStep>>().Object;
+
+                var mockNext = new Mock<IPipelineRequest>();
+                mockNext.Setup(x => x.InvokeAsync(context)).Returns(Task.CompletedTask);
+                var next = mockNext.Object;
+
+                var options = new AppendStreamToFileOptions()
+                {
+                    AppendFileBaseDirectory = outputFilePath
+                };
+
+                var source = new AppendStreamToFileStep(logger, next, options);
+
+                int errorCount = 1;
+
+                string expectedMessage = Pipelines.Resources.NO_KEY_IN_CONTEXT(CultureInfo.CurrentCulture, FileConstants.TARGET_FILE);
+
+                // act
+                await source.InvokeAsync(context).ConfigureAwait(false);
+
+                // assert
+                Assert.AreEqual(errorCount, context.Errors.Count);
+                Assert.IsInstanceOfType(context.Errors[0], typeof(InvalidOperationException));
+                Assert.AreEqual(expectedMessage, context.Errors[0].Message);
+
+                // cleanup
+                await source.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        [TestMethod]
+        public async Task Returns_PipelineContext_Error_From_InvokeAsync_When_FileName_Is_Empty()
+        {
+            // arrange
+            string outputFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}{Path.DirectorySeparatorChar}";
+            string contents = "What is the text here?";
+            byte[] body = Encoding.UTF8.GetBytes(contents);
+
+            using (var stream = new MemoryStream(body))
+            {
+                var context = new PipelineContext();
+                context.Items.Add(FileConstants.TARGET_FILE, string.Empty);
+                context.Items.Add(PipelineContextConstants.OUTPUT_STREAM, stream);
+
+                var logger = new Mock<ILogger<AppendStreamToFileStep>>().Object;
+
+                var mockNext = new Mock<IPipelineRequest>();
+                mockNext.Setup(x => x.InvokeAsync(context)).Returns(Task.CompletedTask);
+                var next = mockNext.Object;
+
+                var options = new AppendStreamToFileOptions()
+                {
+                    AppendFileBaseDirectory = outputFilePath
+                };
+
+                var source = new AppendStreamToFileStep(logger, next, options);
+
+                int errorCount = 1;
+
+                string expectedMessage = Pipelines.Resources.CONTEXT_VALUE_IS_WHITESPACE(CultureInfo.CurrentCulture, FileConstants.TARGET_FILE);
+
+                // act
+                await source.InvokeAsync(context).ConfigureAwait(false);
+
+                // assert
+                Assert.AreEqual(errorCount, context.Errors.Count);
+                Assert.IsInstanceOfType(context.Errors[0], typeof(InvalidOperationException));
+                Assert.AreEqual(expectedMessage, context.Errors[0].Message);
+
+                // cleanup
+                await source.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        [TestMethod]
+        public async Task Returns_PipelineContext_Error_From_InvokeAsync_When_Path_Traversal_Error_Has_Been_Discovered()
+        {
+            // arrange
+            string outputFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}{Path.DirectorySeparatorChar}";
+            string contents = "What is the text here?";
+            byte[] body = Encoding.UTF8.GetBytes(contents);
+
+            string fileName = $"{Guid.NewGuid()}.txt";
+
+            string fullPathAndFileName = outputFilePath + fileName;
+
+            using (var stream = new MemoryStream(body))
+            {
+                var context = new PipelineContext();
+                context.Items.Add(FileConstants.TARGET_FILE, fullPathAndFileName);
+                context.Items.Add(PipelineContextConstants.OUTPUT_STREAM, stream);
+
+                var logger = new Mock<ILogger<AppendStreamToFileStep>>().Object;
+
+                var mockNext = new Mock<IPipelineRequest>();
+                mockNext.Setup(x => x.InvokeAsync(context)).Returns(Task.CompletedTask);
+                var next = mockNext.Object;
+
+                var options = new AppendStreamToFileOptions()
+                {
+                    AppendFileBaseDirectory = $"\\\\argonaut.com\\unavailable-file-share\\{Guid.NewGuid()}\\"
+                };
+
+                var source = new AppendStreamToFileStep(logger, next, options);
+
+                int errorCount = 1;
+
+                string expectedMessage = Resources.PATH_TRAVERSAL_ISSUE(CultureInfo.CurrentCulture, options.AppendFileBaseDirectory, fullPathAndFileName);
+
+                // act
+                await source.InvokeAsync(context).ConfigureAwait(false);
+
+                // assert
+                Assert.AreEqual(errorCount, context.Errors.Count);
+                Assert.IsInstanceOfType(context.Errors[0], typeof(InvalidOperationException));
+                Assert.AreEqual(expectedMessage, context.Errors[0].Message);
+
+                // cleanup
+                await source.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        [TestMethod]
+        public async Task Returns_PipelineContext_Error_From_InvokeAsync_When_OutputStream_Is_Not_In_The_Context()
+        {
+            // arrange
+            string outputFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}{Path.DirectorySeparatorChar}";
+            string contents = "What is the text here?";
+            byte[] body = Encoding.UTF8.GetBytes(contents);
+
+            string fileName = $"{Guid.NewGuid()}.txt";
+
+            using (var stream = new MemoryStream(body))
+            {
+                var context = new PipelineContext();
+                context.Items.Add(FileConstants.TARGET_FILE, fileName);
+
+                var logger = new Mock<ILogger<AppendStreamToFileStep>>().Object;
+
+                var mockNext = new Mock<IPipelineRequest>();
+                mockNext.Setup(x => x.InvokeAsync(context)).Returns(Task.CompletedTask);
+                var next = mockNext.Object;
+
+                var options = new AppendStreamToFileOptions()
+                {
+                    AppendFileBaseDirectory = outputFilePath
+                };
+
+                var source = new AppendStreamToFileStep(logger, next, options);
+
+                int errorCount = 1;
+
+                string expectedMessage = Pipelines.Resources.NO_KEY_IN_CONTEXT(CultureInfo.CurrentCulture, PipelineContextConstants.OUTPUT_STREAM);
+
+                // act
+                await source.InvokeAsync(context).ConfigureAwait(false);
+
+                // assert
+                Assert.AreEqual(errorCount, context.Errors.Count);
+                Assert.IsInstanceOfType(context.Errors[0], typeof(InvalidOperationException));
+                Assert.AreEqual(expectedMessage, context.Errors[0].Message);
+
+                // cleanup
+                await source.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        [TestMethod]
+        public async Task Returns_PipelineContext_Error_From_InvokeAsync_When_OutputStream_Is_Not_A_Stream()
+        {
+            // arrange
+            string outputFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}{Path.DirectorySeparatorChar}";
+
+            string fileName = $"{Guid.NewGuid()}.txt";
+
+            string stream = "Not an Actual Stream object.";
+
+            var context = new PipelineContext();
+            context.Items.Add(FileConstants.TARGET_FILE, fileName);
+            context.Items.Add(PipelineContextConstants.OUTPUT_STREAM, stream);
+
+            var logger = new Mock<ILogger<AppendStreamToFileStep>>().Object;
+
+            var mockNext = new Mock<IPipelineRequest>();
+            mockNext.Setup(x => x.InvokeAsync(context)).Returns(Task.CompletedTask);
+            var next = mockNext.Object;
+
+            var options = new AppendStreamToFileOptions()
+            {
+                AppendFileBaseDirectory = outputFilePath
+            };
+
+            var source = new AppendStreamToFileStep(logger, next, options);
+
+            int errorCount = 1;
+
+            string expectedMessage = Pipelines.Resources.CONTEXT_VALUE_NOT_EXPECTED_TYPE(CultureInfo.CurrentCulture, PipelineContextConstants.OUTPUT_STREAM, typeof(Stream));
+
+            // act
+            await source.InvokeAsync(context).ConfigureAwait(false);
+
+            // assert
+            Assert.AreEqual(errorCount, context.Errors.Count);
+            Assert.IsInstanceOfType(context.Errors[0], typeof(InvalidOperationException));
+            Assert.AreEqual(expectedMessage, context.Errors[0].Message);
+
+            // cleanup
+            await source.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
…n false positive null warnings.

- Add AppendStreamToFileStep and ~Options to allow a stream to be appended to an new or existing file.
- Change the underlying base type for ReadStreamFromFileSystemStep to use the AbstractCachingPipelineStep<TService, TOptions> instead of implementing caching in this class.
- Uncomment the nuget publishing to allow version 3.2.0 to be published.
- Suppress SA1636 to allow for variation in the copyright headers for 2022 and range from 2019-2022.
- Add if-no-files-found to the nuget publish step in build.
- Bump actions/upload-artifact from 2 to 3.
- Uncomment the local Github artifact publish, nuget.org publish, and local Github nuget publish to allow these actions to run again.