### PR TITLE
Upgrade to Pipelines v4 and ancillary changes associated with v4.

### DIFF
--- a/.github/workflows/build-pipelines-steps-communications-http.yaml
+++ b/.github/workflows/build-pipelines-steps-communications-http.yaml
@@ -34,7 +34,7 @@ jobs:
         SOLUTION_NAME: 'MyTrout.Pipelines.Steps.Communications.Http.sln'
         
         # This value should change on each deployable version of this solution.
-        PROJECT_VERSION: '1.1.0'
+        PROJECT_VERSION: '2.0.0'
         
         # These values are used for unit and integration testing
         PIPELINE_TEST_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -47,12 +47,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET Core SDK 5.0.x and 6.0.x
+      - name: Setup .NET Core SDK 6.0.x and 7.0.x
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: |
-            5.0.x
             6.0.x
+            7.0.100-preview.3.22179.4
       
       # "dotnet sonarscanner end" now requires Java 11 to be installed.
       - name: Setup Java 11 for SonarQube.
@@ -90,19 +90,18 @@ jobs:
         run: dotnet sonarscanner end /d:sonar.login=${{ secrets.MYTROUT_SONARQUBE_API_KEY }}      
         if: ${{ github.actor != 'dependabot[bot]' }}
 
-      # - name: Upload nupkg
-      # uses: actions/upload-artifact@v2
-      # with:
-      #    name: nupkg
-      #    path: ${{ env.WORKING_DIRECTORY }}/**/bin/Release/*.nupkg
-      #    if-no-files-found: error
-      #  if: "github.ref == 'refs/heads/master' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
+      - name: Upload nupkg
+        uses: actions/upload-artifact@v2
+        with:
+          name: nupkg
+          path: ${{ env.WORKING_DIRECTORY }}/**/bin/Release/*.nupkg
+          if-no-files-found: error
+        if: "github.ref == 'refs/heads/master' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
         
-      #- name: Publish the package to nuget.org.
-      #  run: dotnet nuget push "${{ env.WORKING_DIRECTORY }}/src/bin/Release/*.nupkg" --api-key ${{ secrets.MYTROUT_NUGET_API_KEY }} --source "https://api.nuget.org/v3/index.json"
-      #  if: "github.ref == 'refs/heads/master' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
+      - name: Publish the package to nuget.org.
+        run: dotnet nuget push "${{ env.WORKING_DIRECTORY }}/src/bin/Release/*.nupkg" --api-key ${{ secrets.MYTROUT_NUGET_API_KEY }} --source "https://api.nuget.org/v3/index.json"
+        if: "github.ref == 'refs/heads/master' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
 
-      # - name: Publish the package to GitHub.
-      #  run: dotnet nuget push "${{ env.WORKING_DIRECTORY }}/src/bin/Release/*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/mytrout/index.json"
-      #  if: "github.ref == 'refs/heads/master' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
-
+      - name: Publish the package to GitHub.
+        run: dotnet nuget push "${{ env.WORKING_DIRECTORY }}/src/bin/Release/*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/mytrout/index.json"
+        if: "github.ref == 'refs/heads/master' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"

--- a/Steps/Communications/Http/changelog.md
+++ b/Steps/Communications/Http/changelog.md
@@ -1,5 +1,19 @@
 # MyTrout.Pipelines.Steps.Communications.Http Change Log
 
+## 2.0.0
+### BREAKING CHANGES:
+- [#160](https://github.com/mytrout/Pipelines/issues/160) Remove support for .NET 5.0. 
+- [#162](https://github.com/mytrout/Pipelines/issues/162) Upgrade to MyTrout.Pipelines 4.0.0 
+### NON-BREAKING CHANGES:
+- [#148](https://github.com/mytrout/Pipelines/issues/148) Refactor SendHttpRequestStep to use AbstractCachingPipelineStep<TStep, TOptions> to guarantee that existing values are restored after execution of this step.
+- [#148](https://github.com/mytrout/Pipelines/issues/148) Add additional unit test to ensure that SendHttpRequestStep restores PipelineContext.Items to its original state after execution.
+- [#160](https://github.com/mytrout/Pipelines/issues/160) Add support for .NET 7.0
+- [#161](https://github.com/mytrout/Pipelines/issues/161) Refactor SendHttpRequestStep and SendHttpRequestOptions to use user-configurable context names for any value read from or written to IPipelineContext.Items.
+- [#161](https://github.com/mytrout/Pipelines/issues/161) Add additional unit test to test that SendHttpRequestOptions ~ContextName values are used when SendHttpRequestStep executes.
+- Uncomment all of the nuget publish steps to allow a new version to be published.
+- Add .editorconfig to enforce rules in Visual Studio 2022.
+- Update Microsoft.CodeAnalysis.NetAnalyzers to .NET 7.0 preview version to eliminate build warnings.
+
 ## 1.1.0 - SonarCloud UPDATE ONLY
  - Removed the null check when returning HttpResponseMessage.Content because it is non-nullable in .NET 5.0 and higher.
  - Suppress SA1636 Copyright Header violations since SendHttpRequestStep.cs is now 2021-2022 Copyright.

--- a/Steps/Communications/Http/src/.editorconfig
+++ b/Steps/Communications/Http/src/.editorconfig
@@ -1,0 +1,135 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+root = true
+
+# All files
+[*]
+indent_style = space
+csharp_using_directive_placement= inside_namespace:error
+csharp_prefer_simple_using_statement= false:error
+dotnet_style_qualification_for_field= true:warning
+dotnet_style_qualification_for_property= true:warning
+dotnet_style_qualification_for_method= true:warning
+dotnet_style_qualification_for_event= true:warning
+dotnet_code_quality.CA1062.null_check_validation_methods = AssertParameterIsNotNull|AssertParameterIsNotWhiteSpace|AssertValueIsValid
+csharp_indent_labels = one_less_than_current
+csharp_space_around_binary_operators = before_and_after
+csharp_prefer_braces = true:error
+csharp_style_namespace_declarations = block_scoped:error
+csharp_style_prefer_method_group_conversion = true:error
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_throw_expression = true:suggestion
+csharp_style_prefer_null_check_over_type_check = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+csharp_prefer_static_local_function = true:suggestion
+csharp_style_allow_embedded_statements_on_same_line_experimental = true:silent
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true:silent
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true:silent
+csharp_style_conditional_delegate_call = true:suggestion
+csharp_style_prefer_parameter_null_checking = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_prefer_pattern_matching = true:silent
+csharp_style_prefer_switch_expression = true:suggestion
+csharp_style_prefer_not_pattern = true:suggestion
+csharp_style_prefer_extended_property_pattern = true:suggestion
+csharp_style_var_for_built_in_types = false:silent
+csharp_style_var_when_type_is_apparent = false:silent
+csharp_style_var_elsewhere = false:silent
+
+# Xml files
+[*.xml]
+indent_size = 2
+
+[*.{cs,vb}]
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+indent_size = 4
+end_of_line = crlf
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_namespace_match_folder = true:suggestion
+dotnet_style_readonly_field = true:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+dotnet_style_allow_multiple_blank_lines_experimental = true:silent
+dotnet_style_allow_statement_immediately_after_block_experimental = true:silent
+dotnet_code_quality_unused_parameters = all:suggestion
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent

--- a/Steps/Communications/Http/src/MyTrout.Pipelines.Steps.Communications.Http.csproj
+++ b/Steps/Communications/Http/src/MyTrout.Pipelines.Steps.Communications.Http.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Chris Trout</Authors>
-    <Copyright>Copyright 2021 Chris Trout. All Rights Reserved.</Copyright>
+    <Copyright>Copyright 2021-2022 Chris Trout. All Rights Reserved.</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Version>0.1.0-beta</Version>
     <NeutralLanguage>en-US</NeutralLanguage>
@@ -38,7 +38,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0-preview1.22168.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -46,7 +46,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MyTrout.Pipelines" Version="3.2.0" />
+    <PackageReference Include="MyTrout.Pipelines" Version="[4,5)" />
     <PackageReference Include="Roslynator.Analyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Steps/Communications/Http/src/SendHttpRequestOptions.cs
+++ b/Steps/Communications/Http/src/SendHttpRequestOptions.cs
@@ -24,6 +24,7 @@
 
 namespace MyTrout.Pipelines.Steps.Communications.Http
 {
+    using MyTrout.Pipelines.Core;
     using System;
     using System.Collections.Generic;
     using System.Net.Http;
@@ -43,7 +44,13 @@ namespace MyTrout.Pipelines.Steps.Communications.Http
         /// </summary>
         public IEnumerable<string> HeaderNames { get; set; } = new List<string>();
 
-#pragma warning disable CS8618 // HttpEndpoint should always be set in options.
+#pragma warning disable CS8618 // HttpClient and HttpEndpoint should always be set in options.
+        /// <summary>
+        /// Gets or sets the <see cref="HttpClient"/> used to make an http request.
+        /// </summary>
+        [FromServices]
+        public HttpClient HttpClient { get; set; }
+
         /// <summary>
         /// Gets or sets the HTTP endpoint to which the stream will be uploaded.
         /// </summary>
@@ -51,12 +58,47 @@ namespace MyTrout.Pipelines.Steps.Communications.Http
 #pragma warning restore CS8618
 
         /// <summary>
+        /// Gets or sets the Status Code Context Name used for <see cref="IPipelineContext.Items"/>.
+        /// </summary>
+        public string HttpStatusCodeContextName { get; set; } = HttpCommunicationConstants.HTTP_STATUS_CODE;
+
+        /// <summary>
+        /// Gets or sets the Reason Phrase Context Name used for <see cref="IPipelineContext.Items"/>.
+        /// </summary>
+        public string HttpReasonPhraseContextName { get; set; } = HttpCommunicationConstants.HTTP_REASON_PHRASE;
+
+        /// <summary>
+        /// Gets or sets the Response Headers Context Name used for <see cref="IPipelineContext.Items"/>.
+        /// </summary>
+        public string HttpResponseHeadersContextName { get; set; } = HttpCommunicationConstants.HTTP_RESPONSE_HEADERS;
+
+        /// <summary>
+        /// Gets or sets the Response Trailing Headers Context Name used for <see cref="IPipelineContext.Items"/>.
+        /// </summary>
+        public string HttpResponseTrailingHeadersContextName { get; set; } = HttpCommunicationConstants.HTTP_RESPONSE_TRAILING_HEADERS;
+
+        /// <summary>
+        /// Gets or sets the Input Stream Context Name used for <see cref="IPipelineContext.Items"/>.
+        /// </summary>
+        public string InputStreamContextName { get; set; } = PipelineContextConstants.INPUT_STREAM;
+
+        /// <summary>
+        /// Gets or sets the Is Status Code Successful Context Name used for <see cref="IPipelineContext.Items"/>.
+        /// </summary>
+        public string IsSuccessfulStatusCodeContextName { get; set; } = HttpCommunicationConstants.HTTP_IS_SUCCESSFUL_STATUS_CODE;
+
+        /// <summary>
         /// Gets or sets the method for the Htto Endpoint call.
         /// </summary>
         public HttpMethod Method { get; set; } = HttpMethod.Post;
 
         /// <summary>
-        /// Gets or sets a value indicating whether gets or sets a value whether the <see cref="PipelineContextConstants.OUTPUT_STREAM" /> contained in <see cref="IPipelineContext.Items"/> should be submitted as <see cref="HttpContent"/> to the <see cref="HttpEndpoint"/>.
+        /// Gets or sets the Output Stream Context Name used for <see cref="IPipelineContext.Items"/>.
+        /// </summary>
+        public string OutputStreamContextName { get; set; } = PipelineContextConstants.OUTPUT_STREAM;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether gets or sets a value whether the <see cref="InputStreamContextName" /> contained in <see cref="IPipelineContext.Items"/> should be submitted as <see cref="HttpContent"/> to the <see cref="HttpEndpoint"/>.
         /// </summary>
         public bool UploadInputStreamAsContent { get; set; } = false;
 


### PR DESCRIPTION
### BREAKING CHANGES:
- #160
- #162
### NON-BREAKING CHANGES:
- #85
- #94
- #148 
-- Refactor SendHttpRequestStep to use AbstractCachingPipelineStep<TStep, TOptions> to guarantee that existing values are restored after execution of this step.
-- Add additional unit test to ensure that SendHttpRequestStep restores PipelineContext.Items to its original state after execution.
- #160
-- Add support for .NET 7.0
- #161
-- Refactor SendHttpRequestStep and SendHttpRequestOptions to use user-configurable context names for any value read from or written to IPipelineContext.Items.
-- Add additional unit test to test that SendHttpRequestOptions ~ContextName values are used when SendHttpRequestStep executes.
- Uncomment all of the nuget publish steps to allow a new version to be published.
- Add .editorconfig to enforce rules in Visual Studio 2022.
- Update Microsoft.CodeAnalysis.NetAnalyzers to .NET 7.0 preview version to eliminate build warnings.