### PR TITLE
Feature/upgrade steps io compression to pipelines 4

### DIFF
--- a/.github/workflows/build-pipelines-steps-io-compression.yaml
+++ b/.github/workflows/build-pipelines-steps-io-compression.yaml
@@ -33,7 +33,7 @@ jobs:
         SOLUTION_NAME: 'MyTrout.Pipelines.Steps.IO.Compression.sln'
         
         # This value should change on each deployable version of this solution.
-        PROJECT_VERSION: '5.0.0'
+        PROJECT_VERSION: '6.0.0'
         
     steps:
       - name: Checkout the Source
@@ -41,13 +41,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET Core SDK 5.0.x and 6.0.x
+      - name: Setup .NET Core SDK 6.0.x and 7.0.x
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: |
-            5.0.x
             6.0.x
-      
+            7.0.100-preview.3.22179.4
+
       # "dotnet sonarscanner end" now requires Java 11 to be installed.
       - name: Setup Java 11 for SonarQube.
         uses: actions/setup-java@v3

--- a/Steps/IO/Compression/README.md
+++ b/Steps/IO/Compression/README.md
@@ -16,7 +16,7 @@
 
 MyTrout.Pipelines.Steps.IO.Compression provides Pipeline steps to manage zip archives and zip archive entries.
 
-MyTrout.Pipelines.Steps.IO.Compression targets [.NET 6.0](https://dotnet.microsoft.com/download/dotnet/6.0)
+MyTrout.Pipelines.Steps.IO.Compression targets [.NET 6.0](https://dotnet.microsoft.com/download/dotnet/6.0) and [.NET 7.0](https://dotnet.microsoft.com/download/dotnet/7.0).
 
 For more details on Pipelines, see [Pipelines.Core](../../Core/README.md)
 
@@ -30,7 +30,7 @@ For a list of available steps, see [Available Steps](../README.md)
 
 ## Software dependencies
 
-    1. MyTrout.Pipelines.Steps 3.2.0 minimum.
+    1. MyTrout.Pipelines.Steps 4.0.0 minimum.
 
 All software dependencies listed above use the [MIT License](https://licenses.nuget.org/MIT).
 

--- a/Steps/IO/Compression/changelog.md
+++ b/Steps/IO/Compression/changelog.md
@@ -1,7 +1,27 @@
 # MyTrout.Pipelines.Steps.IO.Compression
 
+## 6.0.0
+### BREAKING CHANGES:
+- [#160](https://github.com/mytrout/Pipelines/issues/160) Remove support for .NET 5.0. 
+- [#162](https://github.com/mytrout/Pipelines/issues/162) Upgrade to MyTrout.Pipelines 4.0.0 
+- [#161](https://github.com/mytrout/Pipelines/issues/161) Refactor all ~Step and ~Options to use user-configurable context names for any value read from or written to IPipelineContext.Items.
+- [#161](https://github.com/mytrout/Pipelines/issues/161) Add additional unit test to test that ContextName values are used when Steps executes.
+### NON-BREAKING CHANGES:
+- [#160](https://github.com/mytrout/Pipelines/issues/160) Add support for .NET 7.0
+- [#148](https://github.com/mytrout/Pipelines/issues/148) Refactor ~Step to use AbstractCachingPipelineStep<TStep, TOptions> to guarantee that existing INPUT_STREAM values are restored after execution of this step.
+- [#148](https://github.com/mytrout/Pipelines/issues/148) Add additional unit test to ensure that ~Step restores PipelineContext.Items to its original state after execution.
+- Add .editorconfig to enforce rules in Visual Studio 2022.
+- Update Microsoft.CodeAnalysis.NetAnalyzers to .NET 7.0 preview version to eliminate build warnings.
+- Update Microsoft.CodeAnalysis.Analyzers to .NET 7.0 preview version to eliminate build warnings.
+- Update Microsoft.VisualStudio.ThreadingAnalyzers to 17.2.32
+- Upgrade SonarAnalyzer.CSharp 8.40.0.48530
+- Upgrade StyleCop.Analyzers to 1.2.0-beta.435
+- Remove pramga lines in favor of null-forgiving operators and an explanation comment.
+
 ## 5.0.0
-- (BREAKING CHANGE) On OpenExistingZipArchiveFromStreamStep, INPUT_STREAM is no longer copied to OUTPUT_STREAM on the response side.
+### BREAKING CHANGES:
+- On OpenExistingZipArchiveFromStreamStep, INPUT_STREAM is no longer copied to OUTPUT_STREAM on the response side.
+### NON-BREAKING CHANGES:
 - Suppress SA1636 because three file headers have copyrights changed to 2020 - 2022.
 - Alter the build.yaml to include the new version and uncomment the Upload Nuget step.
 - Update Resources.tt to use the new NamespaceHint code so that the Resources.tt can be copied into any project.
@@ -33,7 +53,9 @@
   - Add work_dispatch element to allow this library to to built manually in Github.
 
 ## 3.0.0
+### BREAKING CHANGES:
 - Upgrade to MyTrout.Pipelines v3.0.1
+### NON-BREAKING CHANGES:
 - Change Resources.tt from .NET Standard 2.1 to .NET 5.0 in the comments.
 - Change the nuget PackageURL and RepositoryURL from Azure DevOps to GitHub.
 - Change Build Status badge from Azure DevOps to GitHub Actions.
@@ -53,7 +75,9 @@
 - Update azure-pipelines.xml to add artifactPublishEnabled property.
 
 ## 1.0.0
+### BREAKING CHANGES:
 - Upgrade to MyTrout.Pipelines.Steps v1.0.0 (including MyTrout.Pipelines v1.1.0)
+### NON-BREAKING CHANGES:
 - Generate and publish to Azure DevOps Artifacts the snupkg file for symbols.
 - Implement nullable reference types.
 - Suppress SonarQube S5042 security warnings as they are false positives - 'this may be a problem' rather than 'this *IS* a problem'.

--- a/Steps/IO/Compression/changelog.md
+++ b/Steps/IO/Compression/changelog.md
@@ -10,6 +10,7 @@
 - [#160](https://github.com/mytrout/Pipelines/issues/160) Add support for .NET 7.0
 - [#148](https://github.com/mytrout/Pipelines/issues/148) Refactor ~Step to use AbstractCachingPipelineStep<TStep, TOptions> to guarantee that existing INPUT_STREAM values are restored after execution of this step.
 - [#148](https://github.com/mytrout/Pipelines/issues/148) Add additional unit test to ensure that ~Step restores PipelineContext.Items to its original state after execution.
+- Move parameter and PipelineContext.Items validation to the InvokeBeforeCacheAsync() method for classes implementing AbstractCachingPipelineStep&lt;TStep&gt;
 - Add .editorconfig to enforce rules in Visual Studio 2022.
 - Update Microsoft.CodeAnalysis.NetAnalyzers to .NET 7.0 preview version to eliminate build warnings.
 - Update Microsoft.CodeAnalysis.Analyzers to .NET 7.0 preview version to eliminate build warnings.

--- a/Steps/IO/Compression/src/.editorconfig
+++ b/Steps/IO/Compression/src/.editorconfig
@@ -1,0 +1,135 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+root = true
+
+# All files
+[*]
+indent_style = space
+csharp_using_directive_placement= inside_namespace:error
+csharp_prefer_simple_using_statement= false:error
+dotnet_style_qualification_for_field= true:warning
+dotnet_style_qualification_for_property= true:warning
+dotnet_style_qualification_for_method= true:warning
+dotnet_style_qualification_for_event= true:warning
+dotnet_code_quality.CA1062.null_check_validation_methods = AssertParameterIsNotNull|AssertParameterIsNotWhiteSpace|AssertValueIsValid
+csharp_indent_labels = one_less_than_current
+csharp_space_around_binary_operators = before_and_after
+csharp_prefer_braces = true:error
+csharp_style_namespace_declarations = block_scoped:error
+csharp_style_prefer_method_group_conversion = true:error
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_throw_expression = true:suggestion
+csharp_style_prefer_null_check_over_type_check = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+csharp_prefer_static_local_function = true:suggestion
+csharp_style_allow_embedded_statements_on_same_line_experimental = true:silent
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true:silent
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true:silent
+csharp_style_conditional_delegate_call = true:suggestion
+csharp_style_prefer_parameter_null_checking = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_prefer_pattern_matching = true:silent
+csharp_style_prefer_switch_expression = true:suggestion
+csharp_style_prefer_not_pattern = true:suggestion
+csharp_style_prefer_extended_property_pattern = true:suggestion
+csharp_style_var_for_built_in_types = false:silent
+csharp_style_var_when_type_is_apparent = false:silent
+csharp_style_var_elsewhere = false:silent
+
+# Xml files
+[*.xml]
+indent_size = 2
+
+[*.{cs,vb}]
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+indent_size = 4
+end_of_line = crlf
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_namespace_match_folder = true:suggestion
+dotnet_style_readonly_field = true:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+dotnet_style_allow_multiple_blank_lines_experimental = true:silent
+dotnet_style_allow_statement_immediately_after_block_experimental = true:silent
+dotnet_code_quality_unused_parameters = all:suggestion
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent

--- a/Steps/IO/Compression/src/AbstractZipOptions.cs
+++ b/Steps/IO/Compression/src/AbstractZipOptions.cs
@@ -1,7 +1,7 @@
-﻿// <copyright file="OpenExistingZipArchiveFromStreamOptions.cs" company="Chris Trout">
+﻿// <copyright file="AbstractZipOptions.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2020-2021 Chris Trout
+// Copyright(c) 2022 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,27 +24,26 @@
 
 namespace MyTrout.Pipelines.Steps.IO.Compression
 {
-    using System.IO.Compression;
+    /*
+     *  IMPORTANT NOTE: As long as this class only contains compiler-generated functionality, it requires no unit tests.
+     *
+     *  TO DEVELOPERS: This class is used to define this set of properties once.  Several Steps use the same set.
+     */
 
     /// <summary>
-    /// Provides the user-configurable options for the <see cref="OpenExistingZipArchiveFromStreamStep"/> step.
+    /// Provides caller-configurable options to change the behavior of <see cref="AddZipArchiveEntryStep"/>.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    public class OpenExistingZipArchiveFromStreamOptions
+    public abstract class AbstractZipOptions
     {
         /// <summary>
-        /// Gets or sets the name used for the reading from the input stream from <see cref="IPipelineContext.Items"/>.
+        /// Gets or sets the name used for the writing to the output stream from <see cref="IPipelineContext.Items"/>.
         /// </summary>
-        public string InputStreamContextName { get; set; } = PipelineContextConstants.INPUT_STREAM;
+        public string OutputStreamContextName { get; set; } = PipelineContextConstants.OUTPUT_STREAM;
 
         /// <summary>
         /// Gets or sets the name used for loading the zip archive from <see cref="IPipelineContext.Items"/>.
         /// </summary>
         public string ZipArchiveContextName { get; set; } = CompressionConstants.ZIP_ARCHIVE;
-
-        /// <summary>
-        /// Gets or sets the mode under which the <see cref="ZipArchive"/> will operate.
-        /// </summary>
-        public ZipArchiveMode ZipArchiveMode { get; set; } = ZipArchiveMode.Read;
     }
 }

--- a/Steps/IO/Compression/src/AddZipArchiveEntryOptions.cs
+++ b/Steps/IO/Compression/src/AddZipArchiveEntryOptions.cs
@@ -1,7 +1,7 @@
-﻿// <copyright file="OpenExistingZipArchiveFromStreamOptions.cs" company="Chris Trout">
+﻿// <copyright file="AddZipArchiveEntryOptions.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2020-2021 Chris Trout
+// Copyright(c) 2022 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,27 +24,19 @@
 
 namespace MyTrout.Pipelines.Steps.IO.Compression
 {
-    using System.IO.Compression;
+    /*
+     *  IMPORTANT NOTE: As long as this class only contains compiler-generated functionality, it requires no unit tests.
+     */
 
     /// <summary>
-    /// Provides the user-configurable options for the <see cref="OpenExistingZipArchiveFromStreamStep"/> step.
+    /// Provides caller-configurable options to change the behavior of <see cref="AddZipArchiveEntryStep"/>.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    public class OpenExistingZipArchiveFromStreamOptions
+    public class AddZipArchiveEntryOptions : AbstractZipOptions
     {
         /// <summary>
-        /// Gets or sets the name used for the reading from the input stream from <see cref="IPipelineContext.Items"/>.
+        /// Gets or sets the name used for add an entry to the zip archive from <see cref="IPipelineContext.Items"/>.
         /// </summary>
-        public string InputStreamContextName { get; set; } = PipelineContextConstants.INPUT_STREAM;
-
-        /// <summary>
-        /// Gets or sets the name used for loading the zip archive from <see cref="IPipelineContext.Items"/>.
-        /// </summary>
-        public string ZipArchiveContextName { get; set; } = CompressionConstants.ZIP_ARCHIVE;
-
-        /// <summary>
-        /// Gets or sets the mode under which the <see cref="ZipArchive"/> will operate.
-        /// </summary>
-        public ZipArchiveMode ZipArchiveMode { get; set; } = ZipArchiveMode.Read;
+        public string ZipArchiveEntryNameContextName { get; set; } = CompressionConstants.ZIP_ARCHIVE_ENTRY_NAME;
     }
 }

--- a/Steps/IO/Compression/src/CloseZipArchiveOptions.cs
+++ b/Steps/IO/Compression/src/CloseZipArchiveOptions.cs
@@ -1,7 +1,7 @@
-﻿// <copyright file="OpenExistingZipArchiveFromStreamOptions.cs" company="Chris Trout">
+﻿// <copyright file="CloseZipArchiveOptions.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2020-2021 Chris Trout
+// Copyright(c) 2022 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,27 +24,16 @@
 
 namespace MyTrout.Pipelines.Steps.IO.Compression
 {
-    using System.IO.Compression;
+    /*
+     *  IMPORTANT NOTE: As long as this class only contains compiler-generated functionality, it requires no unit tests.
+     */
 
     /// <summary>
-    /// Provides the user-configurable options for the <see cref="OpenExistingZipArchiveFromStreamStep"/> step.
+    /// Provides caller-configurable options to change the behavior of <see cref="CloseZipArchiveStep"/>.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    public class OpenExistingZipArchiveFromStreamOptions
+    public class CloseZipArchiveOptions : AbstractZipOptions
     {
-        /// <summary>
-        /// Gets or sets the name used for the reading from the input stream from <see cref="IPipelineContext.Items"/>.
-        /// </summary>
-        public string InputStreamContextName { get; set; } = PipelineContextConstants.INPUT_STREAM;
-
-        /// <summary>
-        /// Gets or sets the name used for loading the zip archive from <see cref="IPipelineContext.Items"/>.
-        /// </summary>
-        public string ZipArchiveContextName { get; set; } = CompressionConstants.ZIP_ARCHIVE;
-
-        /// <summary>
-        /// Gets or sets the mode under which the <see cref="ZipArchive"/> will operate.
-        /// </summary>
-        public ZipArchiveMode ZipArchiveMode { get; set; } = ZipArchiveMode.Read;
+        // no additional options are required.
     }
 }

--- a/Steps/IO/Compression/src/CloseZipArchiveStep.cs
+++ b/Steps/IO/Compression/src/CloseZipArchiveStep.cs
@@ -33,15 +33,16 @@ namespace MyTrout.Pipelines.Steps.IO.Compression
     /// <summary>
     /// Unzips a <see cref="System.IO.Stream"/> and calls downstream once for each file in the zip archive.
     /// </summary>
-    public class CloseZipArchiveStep : AbstractPipelineStep<CloseZipArchiveStep>
+    public class CloseZipArchiveStep : AbstractPipelineStep<CloseZipArchiveStep, CloseZipArchiveOptions>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CloseZipArchiveStep" /> class with the specified parameters.
         /// </summary>
         /// <param name="logger">The logger for this step.</param>
+        /// <param name="options">Step-specific options for altering behavior.</param>
         /// <param name="next">The next step in the pipeline.</param>
-        public CloseZipArchiveStep(ILogger<CloseZipArchiveStep> logger, IPipelineRequest next)
-            : base(logger, next)
+        public CloseZipArchiveStep(ILogger<CloseZipArchiveStep> logger, CloseZipArchiveOptions options, IPipelineRequest next)
+            : base(logger, options, next)
         {
             // no op
         }
@@ -55,10 +56,10 @@ namespace MyTrout.Pipelines.Steps.IO.Compression
         {
             await this.Next.InvokeAsync(context);
 
-            context.AssertValueIsValid<ZipArchive>(CompressionConstants.ZIP_ARCHIVE);
-            context.AssertValueIsValid<Stream>(PipelineContextConstants.OUTPUT_STREAM);
+            context.AssertValueIsValid<ZipArchive>(this.Options.ZipArchiveContextName);
+            context.AssertValueIsValid<Stream>(this.Options.OutputStreamContextName);
 
-            (context.Items[CompressionConstants.ZIP_ARCHIVE] as IDisposable)!.Dispose();
+            (context.Items[this.Options.ZipArchiveContextName] as IDisposable)!.Dispose();
 
             await Task.CompletedTask;
         }

--- a/Steps/IO/Compression/src/CreateNewZipArchiveOptions.cs
+++ b/Steps/IO/Compression/src/CreateNewZipArchiveOptions.cs
@@ -1,7 +1,7 @@
-﻿// <copyright file="OpenExistingZipArchiveFromStreamOptions.cs" company="Chris Trout">
+﻿// <copyright file="CreateNewZipArchiveOptions.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2020-2021 Chris Trout
+// Copyright(c) 2022 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,27 +24,16 @@
 
 namespace MyTrout.Pipelines.Steps.IO.Compression
 {
-    using System.IO.Compression;
+    /*
+     *  IMPORTANT NOTE: As long as this class only contains compiler-generated functionality, it requires no unit tests.
+     */
 
     /// <summary>
-    /// Provides the user-configurable options for the <see cref="OpenExistingZipArchiveFromStreamStep"/> step.
+    /// Provides caller-configurable options to change the behavior of <see cref="CreateNewZipArchiveStep"/>.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    public class OpenExistingZipArchiveFromStreamOptions
+    public class CreateNewZipArchiveOptions : AbstractZipOptions
     {
-        /// <summary>
-        /// Gets or sets the name used for the reading from the input stream from <see cref="IPipelineContext.Items"/>.
-        /// </summary>
-        public string InputStreamContextName { get; set; } = PipelineContextConstants.INPUT_STREAM;
-
-        /// <summary>
-        /// Gets or sets the name used for loading the zip archive from <see cref="IPipelineContext.Items"/>.
-        /// </summary>
-        public string ZipArchiveContextName { get; set; } = CompressionConstants.ZIP_ARCHIVE;
-
-        /// <summary>
-        /// Gets or sets the mode under which the <see cref="ZipArchive"/> will operate.
-        /// </summary>
-        public ZipArchiveMode ZipArchiveMode { get; set; } = ZipArchiveMode.Read;
+        // no additional options are required
     }
 }

--- a/Steps/IO/Compression/src/CreateNewZipArchiveStep.cs
+++ b/Steps/IO/Compression/src/CreateNewZipArchiveStep.cs
@@ -60,16 +60,24 @@ namespace MyTrout.Pipelines.Steps.IO.Compression
         {
             using (var outputStream = new MemoryStream())
             {
-                using (ZipArchive zipArchive = new ZipArchive(outputStream, ZipArchiveMode.Create, leaveOpen: true))
+                using (var zipArchive = new ZipArchive(outputStream, ZipArchiveMode.Create, leaveOpen: true))
                 {
-                    this.Logger.LogInformation(Resources.ZIP_ARCHIVE_OPENED(CultureInfo.CurrentCulture, nameof(CreateNewZipArchiveStep)));
+                    try
+                    {
+                        this.Logger.LogInformation(Resources.ZIP_ARCHIVE_OPENED(CultureInfo.CurrentCulture, nameof(CreateNewZipArchiveStep)));
 
-                    context.Items.Add(this.Options.OutputStreamContextName, outputStream);
-                    context.Items.Add(this.Options.ZipArchiveContextName, zipArchive);
+                        context.Items.Add(this.Options.OutputStreamContextName, outputStream);
+                        context.Items.Add(this.Options.ZipArchiveContextName, zipArchive);
 
-                    this.Logger.LogDebug(Resources.ZIP_ARCHIVE_ADDED_TO_PIPELINE(CultureInfo.CurrentCulture));
+                        this.Logger.LogDebug(Resources.ZIP_ARCHIVE_ADDED_TO_PIPELINE(CultureInfo.CurrentCulture));
 
-                    await this.Next.InvokeAsync(context).ConfigureAwait(false);
+                        await this.Next.InvokeAsync(context).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        context.Items.Remove(this.Options.OutputStreamContextName);
+                        context.Items.Remove(this.Options.ZipArchiveContextName);
+                    }
                 }
             }
         }

--- a/Steps/IO/Compression/src/MyTrout.Pipelines.Steps.IO.Compression.csproj
+++ b/Steps/IO/Compression/src/MyTrout.Pipelines.Steps.IO.Compression.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Chris Trout</Authors>
-    <Copyright>Copyright 2020-2021 Chris Trout. All Rights Reserved.</Copyright>
+    <Copyright>Copyright 2020-2022 Chris Trout. All Rights Reserved.</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Version>0.1.0-beta</Version>
     <NeutralLanguage>en-US</NeutralLanguage>
@@ -35,28 +35,28 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4-beta1.22274.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0-preview1.22274.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.0.64">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.2.32">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MyTrout.Pipelines" Version="[3.2.0,4.0)" />
-    <PackageReference Include="Roslynator.Analyzers" Version="3.3.0">
+    <PackageReference Include="MyTrout.Pipelines" Version="[4,5)" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.33.0.40503">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.40.0.48530">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.376">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Steps/IO/Compression/src/ReadZipArchiveEntriesFromZipArchiveOptions.cs
+++ b/Steps/IO/Compression/src/ReadZipArchiveEntriesFromZipArchiveOptions.cs
@@ -1,7 +1,7 @@
-﻿// <copyright file="OpenExistingZipArchiveFromStreamOptions.cs" company="Chris Trout">
+﻿// <copyright file="ReadZipArchiveEntriesFromZipArchiveOptions.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2020-2021 Chris Trout
+// Copyright(c) 2022 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,27 +24,19 @@
 
 namespace MyTrout.Pipelines.Steps.IO.Compression
 {
-    using System.IO.Compression;
+    /*
+     *  IMPORTANT NOTE: As long as this class only contains compiler-generated functionality, it requires no unit tests.
+     */
 
     /// <summary>
-    /// Provides the user-configurable options for the <see cref="OpenExistingZipArchiveFromStreamStep"/> step.
+    /// Provides caller-configurable options to change the behavior of <see cref="ReadZipArchiveEntriesFromZipArchiveStep"/>.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    public class OpenExistingZipArchiveFromStreamOptions
+    public class ReadZipArchiveEntriesFromZipArchiveOptions : AbstractZipOptions
     {
         /// <summary>
-        /// Gets or sets the name used for the reading from the input stream from <see cref="IPipelineContext.Items"/>.
+        /// Gets or sets the name used for add an entry to the zip archive from <see cref="IPipelineContext.Items"/>.
         /// </summary>
-        public string InputStreamContextName { get; set; } = PipelineContextConstants.INPUT_STREAM;
-
-        /// <summary>
-        /// Gets or sets the name used for loading the zip archive from <see cref="IPipelineContext.Items"/>.
-        /// </summary>
-        public string ZipArchiveContextName { get; set; } = CompressionConstants.ZIP_ARCHIVE;
-
-        /// <summary>
-        /// Gets or sets the mode under which the <see cref="ZipArchive"/> will operate.
-        /// </summary>
-        public ZipArchiveMode ZipArchiveMode { get; set; } = ZipArchiveMode.Read;
+        public string ZipArchiveEntryNameContextName { get; set; } = CompressionConstants.ZIP_ARCHIVE_ENTRY_NAME;
     }
 }

--- a/Steps/IO/Compression/src/ReadZipArchiveEntriesFromZipArchiveStep.cs
+++ b/Steps/IO/Compression/src/ReadZipArchiveEntriesFromZipArchiveStep.cs
@@ -51,17 +51,27 @@ namespace MyTrout.Pipelines.Steps.IO.Compression
         public override IEnumerable<string> CachedItemNames => new List<string>() { this.Options.OutputStreamContextName, this.Options.ZipArchiveEntryNameContextName };
 
         /// <summary>
+        /// Guarantees that <see cref="ReadZipArchiveEntriesFromZipArchiveOptions.ZipArchiveEntryNameContextName"/> exists and is readable.
+        /// </summary>
+        /// <param name="context">The pipeline context.</param>
+        /// <returns>A completed <see cref="Task" />.</returns>
+        protected override Task InvokeBeforeCacheAsync(IPipelineContext context)
+        {
+            context.AssertZipArchiveIsReadable(this.Options.ZipArchiveContextName);
+
+            this.Logger.LogDebug(Resources.INFO_VALIDATED(CultureInfo.CurrentCulture, nameof(ReadZipArchiveEntriesFromZipArchiveStep)));
+
+            return base.InvokeBeforeCacheAsync(context);
+        }
+
+        /// <summary>
         /// Read <see cref="ZipArchiveEntry"/> values contains within the <see cref="ZipArchive"/> provided to this step.
         /// </summary>
         /// <param name="context">The pipeline context.</param>
         /// <returns>A completed <see cref="Task" />.</returns>
         protected override async Task InvokeCachedCoreAsync(IPipelineContext context)
         {
-            context.AssertZipArchiveIsReadable(this.Options.ZipArchiveContextName);
-
-            this.Logger.LogDebug(Resources.INFO_VALIDATED(CultureInfo.CurrentCulture, nameof(ReadZipArchiveEntriesFromZipArchiveStep)));
-
-            // Null-forgiving operator at the end of this line because context.AssertZipArchiveIsReadable ensures non-null ZipArchive-typed value.
+            // Null-forgiving operator at the end of this line because InvokeBeforeCacheAsync validates all required values.
             ZipArchive zipArchive = (context.Items[this.Options.ZipArchiveContextName] as ZipArchive)!;
 
             this.Logger.LogDebug(Resources.INFO_LOADED(CultureInfo.CurrentCulture, nameof(ReadZipArchiveEntriesFromZipArchiveStep)));

--- a/Steps/IO/Compression/src/RemoveZipArchiveEntryOptions.cs
+++ b/Steps/IO/Compression/src/RemoveZipArchiveEntryOptions.cs
@@ -1,7 +1,7 @@
-﻿// <copyright file="OpenExistingZipArchiveFromStreamOptions.cs" company="Chris Trout">
+﻿// <copyright file="RemoveZipArchiveEntryOptions.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2020-2021 Chris Trout
+// Copyright(c) 2022 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,27 +24,24 @@
 
 namespace MyTrout.Pipelines.Steps.IO.Compression
 {
-    using System.IO.Compression;
+    /*
+     *  IMPORTANT NOTE: As long as this class only contains compiler-generated functionality, it requires no unit tests.
+     */
 
     /// <summary>
-    /// Provides the user-configurable options for the <see cref="OpenExistingZipArchiveFromStreamStep"/> step.
+    /// Provides caller-configurable options to change the behavior of <see cref="RemoveZipArchiveEntryStep"/>.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    public class OpenExistingZipArchiveFromStreamOptions
+    public class RemoveZipArchiveEntryOptions
     {
-        /// <summary>
-        /// Gets or sets the name used for the reading from the input stream from <see cref="IPipelineContext.Items"/>.
-        /// </summary>
-        public string InputStreamContextName { get; set; } = PipelineContextConstants.INPUT_STREAM;
-
         /// <summary>
         /// Gets or sets the name used for loading the zip archive from <see cref="IPipelineContext.Items"/>.
         /// </summary>
         public string ZipArchiveContextName { get; set; } = CompressionConstants.ZIP_ARCHIVE;
 
         /// <summary>
-        /// Gets or sets the mode under which the <see cref="ZipArchive"/> will operate.
+        /// Gets or sets the name used for add an entry to the zip archive from <see cref="IPipelineContext.Items"/>.
         /// </summary>
-        public ZipArchiveMode ZipArchiveMode { get; set; } = ZipArchiveMode.Read;
+        public string ZipArchiveEntryNameContextName { get; set; } = CompressionConstants.ZIP_ARCHIVE_ENTRY_NAME;
     }
 }

--- a/Steps/IO/Compression/src/Resources.cs
+++ b/Steps/IO/Compression/src/Resources.cs
@@ -221,6 +221,54 @@ namespace MyTrout.Pipelines.Steps.IO.Compression
 		}
 
 		/// <summary>
+		/// Looks up a localized string like "An zip archive entry named '{0}' was not found in the current Zip Archive.".
+		/// </summary>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings", Justification = "This is T4-generated code.")]
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", Justification = "This is T4-generated code from a resources file.")]
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1707:IdentifiersShouldNotContainUnderscores", Justification = "This is T4-generated code from a resources file.")]
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", Justification = "This is T4-generated code from a resources file.")]
+		public static string ZIP_ARCHIVE_ENTRY_NOT_FOUND()
+		{
+			return Resources.ZIP_ARCHIVE_ENTRY_NOT_FOUND(CultureInfo.CurrentCulture);
+		}
+
+		/// <summary>
+		/// Looks up a localized string using a specific culture like "An zip archive entry named '{0}' was not found in the current Zip Archive.".
+		/// </summary>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings", Justification = "This is T4-generated code.")]
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", Justification = "This is T4-generated code from a resources file.")]
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1707:IdentifiersShouldNotContainUnderscores", Justification = "This is T4-generated code from a resources file.")]
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", Justification = "This is T4-generated code from a resources file.")]
+		public static string ZIP_ARCHIVE_ENTRY_NOT_FOUND(CultureInfo culture)
+		{
+			return Resources.ResourceManager.GetString("ZIP_ARCHIVE_ENTRY_NOT_FOUND", culture);
+		}
+				
+		/// <summary>
+		/// Looks up a localized string using a specific culture like "An zip archive entry named '{0}' was not found in the current Zip Archive.".
+		/// </summary>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings", Justification = "This is T4-generated code.")]
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", Justification = "This is T4-generated code from a resources file.")]
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1707:IdentifiersShouldNotContainUnderscores", Justification = "This is T4-generated code from a resources file.")]
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", Justification = "This is T4-generated code from a resources file.")]
+		public static string ZIP_ARCHIVE_ENTRY_NOT_FOUND(params object[] args)
+		{
+			return Resources.ZIP_ARCHIVE_ENTRY_NOT_FOUND(CultureInfo.CurrentCulture, args);
+		}
+
+		/// <summary>
+		/// Looks up a localized string using a specific culture like "An zip archive entry named '{0}' was not found in the current Zip Archive.".
+		/// </summary>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings", Justification = "This is T4-generated code.")]
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", Justification = "This is T4-generated code from a resources file.")]
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1707:IdentifiersShouldNotContainUnderscores", Justification = "This is T4-generated code from a resources file.")]
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", Justification = "This is T4-generated code from a resources file.")]
+		public static string ZIP_ARCHIVE_ENTRY_NOT_FOUND(CultureInfo culture, params object[] args)
+		{
+			return string.Format(culture, Resources.ResourceManager.GetString("ZIP_ARCHIVE_ENTRY_NOT_FOUND", culture), args);
+		}
+
+		/// <summary>
 		/// Looks up a localized string like "An zip archive entry named '{0}' has been removed.".
 		/// </summary>
 		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings", Justification = "This is T4-generated code.")]

--- a/Steps/IO/Compression/src/Resources.en-GB.resx
+++ b/Steps/IO/Compression/src/Resources.en-GB.resx
@@ -129,6 +129,9 @@
   <data name="ZIP_ARCHIVE_ENTRY_CREATED" xml:space="preserve">
     <value>An zip archive entry named '{0}' has been created.</value>
   </data>
+  <data name="ZIP_ARCHIVE_ENTRY_NOT_FOUND" xml:space="preserve">
+    <value>An zip archive entry named '{0}' was not found in the current Zip Archive.</value>
+  </data>
   <data name="ZIP_ARCHIVE_ENTRY_REMOVED" xml:space="preserve">
     <value>An zip archive entry named '{0}' has been removed.</value>
   </data>

--- a/Steps/IO/Compression/src/Resources.resx
+++ b/Steps/IO/Compression/src/Resources.resx
@@ -129,6 +129,9 @@
   <data name="ZIP_ARCHIVE_ENTRY_CREATED" xml:space="preserve">
     <value>An zip archive entry named '{0}' has been created.</value>
   </data>
+  <data name="ZIP_ARCHIVE_ENTRY_NOT_FOUND" xml:space="preserve">
+    <value>An zip archive entry named '{0}' was not found in the current Zip Archive.</value>
+  </data>
   <data name="ZIP_ARCHIVE_ENTRY_REMOVED" xml:space="preserve">
     <value>An zip archive entry named '{0}' has been removed.</value>
   </data>

--- a/Steps/IO/Compression/src/UpdateZipArchiveEntryOptions.cs
+++ b/Steps/IO/Compression/src/UpdateZipArchiveEntryOptions.cs
@@ -1,7 +1,7 @@
-﻿// <copyright file="OpenExistingZipArchiveFromStreamOptions.cs" company="Chris Trout">
+﻿// <copyright file="UpdateZipArchiveEntryOptions.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2020-2021 Chris Trout
+// Copyright(c) 2022 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,27 +24,19 @@
 
 namespace MyTrout.Pipelines.Steps.IO.Compression
 {
-    using System.IO.Compression;
+    /*
+     *  IMPORTANT NOTE: As long as this class only contains compiler-generated functionality, it requires no unit tests.
+     */
 
     /// <summary>
-    /// Provides the user-configurable options for the <see cref="OpenExistingZipArchiveFromStreamStep"/> step.
+    /// Provides caller-configurable options to change the behavior of <see cref="UpdateZipArchiveEntryStep"/>.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    public class OpenExistingZipArchiveFromStreamOptions
+    public class UpdateZipArchiveEntryOptions : AbstractZipOptions
     {
         /// <summary>
-        /// Gets or sets the name used for the reading from the input stream from <see cref="IPipelineContext.Items"/>.
+        /// Gets or sets the name used for add an entry to the zip archive from <see cref="IPipelineContext.Items"/>.
         /// </summary>
-        public string InputStreamContextName { get; set; } = PipelineContextConstants.INPUT_STREAM;
-
-        /// <summary>
-        /// Gets or sets the name used for loading the zip archive from <see cref="IPipelineContext.Items"/>.
-        /// </summary>
-        public string ZipArchiveContextName { get; set; } = CompressionConstants.ZIP_ARCHIVE;
-
-        /// <summary>
-        /// Gets or sets the mode under which the <see cref="ZipArchive"/> will operate.
-        /// </summary>
-        public ZipArchiveMode ZipArchiveMode { get; set; } = ZipArchiveMode.Read;
+        public string ZipArchiveEntryNameContextName { get; set; } = CompressionConstants.ZIP_ARCHIVE_ENTRY_NAME;
     }
 }

--- a/Steps/IO/Compression/src/UpdateZipArchiveEntryStep.cs
+++ b/Steps/IO/Compression/src/UpdateZipArchiveEntryStep.cs
@@ -25,6 +25,7 @@
 namespace MyTrout.Pipelines.Steps.IO.Compression
 {
     using Microsoft.Extensions.Logging;
+    using System;
     using System.Globalization;
     using System.IO;
     using System.IO.Compression;
@@ -71,7 +72,11 @@ namespace MyTrout.Pipelines.Steps.IO.Compression
 
             var archiveEntry = zipArchive.GetEntry(zipEntryFileName);
 
-            if (archiveEntry != null)
+            if (archiveEntry == null)
+            {
+                throw new InvalidOperationException(Resources.ZIP_ARCHIVE_ENTRY_NOT_FOUND(CultureInfo.CurrentCulture, zipEntryFileName));
+            }
+            else
             {
                 using (var archiveStream = archiveEntry.Open())
                 {

--- a/Steps/IO/Compression/src/UpdateZipArchiveEntryStep.cs
+++ b/Steps/IO/Compression/src/UpdateZipArchiveEntryStep.cs
@@ -1,7 +1,7 @@
 ﻿// <copyright file="UpdateZipArchiveEntryStep.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2020-2021 Chris Trout
+// Copyright(c) 2020-2022 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -33,15 +33,16 @@ namespace MyTrout.Pipelines.Steps.IO.Compression
     /// <summary>
     /// Adds a <see cref="ZipArchiveEntry"/> to the <see cref="ZipArchive"/> provided by a previous step.
     /// </summary>
-    public class UpdateZipArchiveEntryStep : AbstractPipelineStep<UpdateZipArchiveEntryStep>
+    public class UpdateZipArchiveEntryStep : AbstractPipelineStep<UpdateZipArchiveEntryStep, UpdateZipArchiveEntryOptions>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="UpdateZipArchiveEntryStep" /> class with the specified parameters.
         /// </summary>
         /// <param name="logger">The logger for this step.</param>
+        /// <param name="options">Step-specific options for altering behavior.</param>
         /// <param name="next">The next step in the pipeline.</param>
-        public UpdateZipArchiveEntryStep(ILogger<UpdateZipArchiveEntryStep> logger, IPipelineRequest next)
-            : base(logger, next)
+        public UpdateZipArchiveEntryStep(ILogger<UpdateZipArchiveEntryStep> logger, UpdateZipArchiveEntryOptions options, IPipelineRequest next)
+            : base(logger, options, next)
         {
             // no op
         }
@@ -55,28 +56,29 @@ namespace MyTrout.Pipelines.Steps.IO.Compression
         {
             await this.Next.InvokeAsync(context).ConfigureAwait(false);
 
-            context.AssertValueIsValid<Stream>(PipelineContextConstants.OUTPUT_STREAM);
-            context.AssertZipArchiveIsUpdatable(CompressionConstants.ZIP_ARCHIVE);
-            context.AssertStringIsNotWhiteSpace(CompressionConstants.ZIP_ARCHIVE_ENTRY_NAME);
+            context.AssertValueIsValid<Stream>(this.Options.OutputStreamContextName);
+            context.AssertZipArchiveIsUpdatable(this.Options.ZipArchiveContextName);
+            context.AssertStringIsNotWhiteSpace(this.Options.ZipArchiveEntryNameContextName);
 
             this.Logger.LogDebug(Resources.INFO_VALIDATED(CultureInfo.CurrentCulture, nameof(UpdateZipArchiveEntryStep)));
 
-            var outputStream = context.Items[PipelineContextConstants.OUTPUT_STREAM] as Stream;
-            var zipArchive = context.Items[CompressionConstants.ZIP_ARCHIVE] as ZipArchive;
+            var outputStream = (context.Items[this.Options.OutputStreamContextName] as Stream)!;
+            var zipArchive = (context.Items[this.Options.ZipArchiveContextName] as ZipArchive)!;
 
-#pragma warning disable CS8600, CS8602, CS8604 // AssertValueIsValid guarantees that this value is not null.
-            string zipEntryFileName = context.Items[CompressionConstants.ZIP_ARCHIVE_ENTRY_NAME] as string;
+            string zipEntryFileName = (context.Items[this.Options.ZipArchiveEntryNameContextName] as string)!;
 
             this.Logger.LogDebug(Resources.INFO_LOADED(CultureInfo.CurrentCulture, nameof(UpdateZipArchiveEntryStep), zipEntryFileName));
 
             var archiveEntry = zipArchive.GetEntry(zipEntryFileName);
 
-            using (var archiveStream = archiveEntry.Open())
+            if (archiveEntry != null)
             {
-                await outputStream.CopyToAsync(archiveStream).ConfigureAwait(false);
-#pragma warning restore CS8600, CS8602, CS8604
+                using (var archiveStream = archiveEntry.Open())
+                {
+                    await outputStream.CopyToAsync(archiveStream).ConfigureAwait(false);
 
-                this.Logger.LogInformation(Resources.ZIP_ARCHIVE_ENTRY_UPDATED(CultureInfo.CurrentCulture, zipEntryFileName));
+                    this.Logger.LogInformation(Resources.ZIP_ARCHIVE_ENTRY_UPDATED(CultureInfo.CurrentCulture, zipEntryFileName));
+                }
             }
         }
     }

--- a/Steps/IO/Compression/test/.editorconfig
+++ b/Steps/IO/Compression/test/.editorconfig
@@ -1,0 +1,135 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+root = true
+
+# All files
+[*]
+indent_style = space
+csharp_using_directive_placement= inside_namespace:error
+csharp_prefer_simple_using_statement= false:error
+dotnet_style_qualification_for_field= true:warning
+dotnet_style_qualification_for_property= true:warning
+dotnet_style_qualification_for_method= true:warning
+dotnet_style_qualification_for_event= true:warning
+dotnet_code_quality.CA1062.null_check_validation_methods = AssertParameterIsNotNull|AssertParameterIsNotWhiteSpace|AssertValueIsValid
+csharp_indent_labels = one_less_than_current
+csharp_space_around_binary_operators = before_and_after
+csharp_prefer_braces = true:error
+csharp_style_namespace_declarations = block_scoped:error
+csharp_style_prefer_method_group_conversion = true:error
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_throw_expression = true:suggestion
+csharp_style_prefer_null_check_over_type_check = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+csharp_prefer_static_local_function = true:suggestion
+csharp_style_allow_embedded_statements_on_same_line_experimental = true:silent
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true:silent
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true:silent
+csharp_style_conditional_delegate_call = true:suggestion
+csharp_style_prefer_parameter_null_checking = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_prefer_pattern_matching = true:silent
+csharp_style_prefer_switch_expression = true:suggestion
+csharp_style_prefer_not_pattern = true:suggestion
+csharp_style_prefer_extended_property_pattern = true:suggestion
+csharp_style_var_for_built_in_types = false:silent
+csharp_style_var_when_type_is_apparent = false:silent
+csharp_style_var_elsewhere = false:silent
+
+# Xml files
+[*.xml]
+indent_size = 2
+
+[*.{cs,vb}]
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+indent_size = 4
+end_of_line = crlf
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_namespace_match_folder = true:suggestion
+dotnet_style_readonly_field = true:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+dotnet_style_allow_multiple_blank_lines_experimental = true:silent
+dotnet_style_allow_statement_immediately_after_block_experimental = true:silent
+dotnet_code_quality_unused_parameters = all:suggestion
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent

--- a/Steps/IO/Compression/test/AddZipArchiveEntryStepTests.cs
+++ b/Steps/IO/Compression/test/AddZipArchiveEntryStepTests.cs
@@ -1,7 +1,7 @@
 // <copyright file="AddZipArchiveEntryStepTests.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2020-2021 Chris Trout
+// Copyright(c) 2020-2022 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -49,14 +49,16 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
         {
             // arrange
             var logger = new Mock<ILogger<AddZipArchiveEntryStep>>().Object;
+            var options = new AddZipArchiveEntryOptions();
             var next = new Mock<IPipelineRequest>().Object;
 
             // act
-            await using (var result = new AddZipArchiveEntryStep(logger, next))
+            await using (var result = new AddZipArchiveEntryStep(logger, options, next))
             {
                 // assert
                 Assert.IsNotNull(result);
                 Assert.AreEqual(logger, result.Logger);
+                Assert.AreEqual(options, result.Options);
                 Assert.AreEqual(next, result.Next);
             }
         }
@@ -68,6 +70,7 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
             var context = new PipelineContext();
 
             var logger = new Mock<ILogger<AddZipArchiveEntryStep>>().Object;
+            var options = new AddZipArchiveEntryOptions();
             var next = new Mock<IPipelineRequest>().Object;
 
             string entryName = "Disney.txt";
@@ -75,7 +78,7 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
             string zipFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}{Path.DirectorySeparatorChar}Disney.zip";
 
             int expectedErrorCount = 1;
-            string expectedMessage = Pipelines.Resources.NO_KEY_IN_CONTEXT(CultureInfo.CurrentCulture, PipelineContextConstants.OUTPUT_STREAM);
+            string expectedMessage = Pipelines.Resources.NO_KEY_IN_CONTEXT(CultureInfo.CurrentCulture, options.OutputStreamContextName);
 
             using (var zipStream = new MemoryStream())
             {
@@ -88,10 +91,10 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
                 {
                     using (var entryStream = new MemoryStream(Encoding.UTF8.GetBytes(entryContents)))
                     {
-                        context.Items.Add(CompressionConstants.ZIP_ARCHIVE, zipArchive);
-                        context.Items.Add(CompressionConstants.ZIP_ARCHIVE_ENTRY_NAME, entryName);
+                        context.Items.Add(options.ZipArchiveContextName, zipArchive);
+                        context.Items.Add(options.ZipArchiveEntryNameContextName, entryName);
 
-                        await using (var source = new AddZipArchiveEntryStep(logger, next))
+                        await using (var source = new AddZipArchiveEntryStep(logger, options, next))
                         {
                             // act
                             await source.InvokeAsync(context).ConfigureAwait(false);
@@ -113,19 +116,20 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
             var context = new PipelineContext();
 
             var logger = new Mock<ILogger<AddZipArchiveEntryStep>>().Object;
+            var options = new AddZipArchiveEntryOptions();
             var next = new Mock<IPipelineRequest>().Object;
 
             string entryName = "Disney.txt";
 
             int expectedErrorCount = 1;
-            string expectedMessage = Pipelines.Resources.NO_KEY_IN_CONTEXT(CultureInfo.CurrentCulture, CompressionConstants.ZIP_ARCHIVE);
+            string expectedMessage = Pipelines.Resources.NO_KEY_IN_CONTEXT(CultureInfo.CurrentCulture, options.ZipArchiveContextName);
 
             using (var entryStream = new MemoryStream())
             {
-                context.Items.Add(CompressionConstants.ZIP_ARCHIVE_ENTRY_NAME, entryName);
-                context.Items.Add(PipelineContextConstants.OUTPUT_STREAM, entryStream);
+                context.Items.Add(options.ZipArchiveEntryNameContextName, entryName);
+                context.Items.Add(options.OutputStreamContextName, entryStream);
 
-                await using (var source = new AddZipArchiveEntryStep(logger, next))
+                await using (var source = new AddZipArchiveEntryStep(logger, options, next))
                 {
                     // act
                     await source.InvokeAsync(context).ConfigureAwait(false);
@@ -145,13 +149,14 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
             var context = new PipelineContext();
 
             var logger = new Mock<ILogger<AddZipArchiveEntryStep>>().Object;
+            var options = new AddZipArchiveEntryOptions();
             var next = new Mock<IPipelineRequest>().Object;
 
             string entryContents = "Why are you still whining?";
             string zipFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}{Path.DirectorySeparatorChar}Disney.zip";
 
             int expectedErrorCount = 1;
-            string expectedMessage = Pipelines.Resources.NO_KEY_IN_CONTEXT(CultureInfo.CurrentCulture, CompressionConstants.ZIP_ARCHIVE_ENTRY_NAME);
+            string expectedMessage = Pipelines.Resources.NO_KEY_IN_CONTEXT(CultureInfo.CurrentCulture, options.ZipArchiveEntryNameContextName);
 
             using (var zipStream = new MemoryStream())
             {
@@ -164,10 +169,10 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
                 {
                     using (var entryStream = new MemoryStream(Encoding.UTF8.GetBytes(entryContents)))
                     {
-                        context.Items.Add(CompressionConstants.ZIP_ARCHIVE, zipArchive);
-                        context.Items.Add(PipelineContextConstants.OUTPUT_STREAM, entryStream);
+                        context.Items.Add(options.ZipArchiveContextName, zipArchive);
+                        context.Items.Add(options.OutputStreamContextName, entryStream);
 
-                        await using (var source = new AddZipArchiveEntryStep(logger, next))
+                        await using (var source = new AddZipArchiveEntryStep(logger, options, next))
                         {
                             // act
                             await source.InvokeAsync(context).ConfigureAwait(false);
@@ -190,6 +195,8 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
 
             ILogger<AddZipArchiveEntryStep> logger = new Mock<ILogger<AddZipArchiveEntryStep>>().Object;
 
+            var options = new AddZipArchiveEntryOptions();
+
             var mockNext = new Mock<IPipelineRequest>();
             mockNext.Setup(x => x.InvokeAsync(context)).Returns(Task.CompletedTask);
             IPipelineRequest next = mockNext.Object;
@@ -210,11 +217,11 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
                 {
                     using (var entryStream = new MemoryStream(Encoding.UTF8.GetBytes(entryContents)))
                     {
-                        context.Items.Add(CompressionConstants.ZIP_ARCHIVE, zipArchive);
-                        context.Items.Add(CompressionConstants.ZIP_ARCHIVE_ENTRY_NAME, entryName);
-                        context.Items.Add(PipelineContextConstants.OUTPUT_STREAM, entryStream);
+                        context.Items.Add(options.ZipArchiveContextName, zipArchive);
+                        context.Items.Add(options.ZipArchiveEntryNameContextName, entryName);
+                        context.Items.Add(options.OutputStreamContextName, entryStream);
 
-                        await using (var source = new AddZipArchiveEntryStep(logger, next))
+                        await using (var source = new AddZipArchiveEntryStep(logger, options, next))
                         {
                             // act
                             await source.InvokeAsync(context).ConfigureAwait(false);
@@ -226,12 +233,89 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
                             throw context.Errors[0];
                         }
 
-                        Assert.IsTrue(context.Items.ContainsKey(CompressionConstants.ZIP_ARCHIVE), "ZipArchive should exist in context.");
-                        Assert.AreEqual(zipArchive, context.Items[CompressionConstants.ZIP_ARCHIVE]);
-                        Assert.IsTrue(context.Items.ContainsKey(CompressionConstants.ZIP_ARCHIVE_ENTRY_NAME), "ZipArchiveEntryName should exist in context.");
-                        Assert.AreEqual(entryName, context.Items[CompressionConstants.ZIP_ARCHIVE_ENTRY_NAME]);
-                        Assert.IsTrue(context.Items.ContainsKey(PipelineContextConstants.OUTPUT_STREAM), "OutputStream should exist in context.");
-                        Assert.IsTrue((context.Items[PipelineContextConstants.OUTPUT_STREAM] as Stream).CanRead, "OutputStream should not be closed.");
+                        Assert.IsTrue(context.Items.ContainsKey(options.ZipArchiveContextName), "ZipArchive should exist in context.");
+                        Assert.AreEqual(zipArchive, context.Items[options.ZipArchiveContextName]);
+                        Assert.IsTrue(context.Items.ContainsKey(options.ZipArchiveEntryNameContextName), "ZipArchiveEntryName should exist in context.");
+                        Assert.AreEqual(entryName, context.Items[options.ZipArchiveEntryNameContextName]);
+                        Assert.IsTrue(context.Items.ContainsKey(options.OutputStreamContextName), "OutputStream should exist in context.");
+                        Assert.IsTrue((context.Items[options.OutputStreamContextName] as Stream).CanRead, "OutputStream should not be closed.");
+                    }
+                }
+
+                // assert that ZipArchive is usable and the update was accepted.
+                zipStream.Position = 0;
+                using (var assertArchive = new ZipArchive(zipStream))
+                {
+                    Assert.AreEqual(expectedEntryCount, assertArchive.Entries.Count);
+                    var assertEntry = assertArchive.GetEntry(entryName);
+                    using (var assertEntryStream = assertEntry.Open())
+                    {
+                        using (var reader = new StreamReader(assertEntryStream, leaveOpen: true))
+                        {
+                            Assert.AreEqual(entryContents, await reader.ReadToEndAsync().ConfigureAwait(false));
+                        }
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task Returns_ZipArchive_From_InvokeAsync_When_Options_Uses_Different_Context_Names()
+        {
+            // arrange
+            var context = new PipelineContext();
+
+            ILogger<AddZipArchiveEntryStep> logger = new Mock<ILogger<AddZipArchiveEntryStep>>().Object;
+
+            var options = new AddZipArchiveEntryOptions()
+            {
+                ZipArchiveContextName = "ZIP_ARCHIVE_TESTING",
+                ZipArchiveEntryNameContextName = "ZIP_ARCHIVE_ENTRY_NAME_TESTING",
+                OutputStreamContextName = "OUTPUT_STREAM_TESTING"
+            };
+
+            var mockNext = new Mock<IPipelineRequest>();
+            mockNext.Setup(x => x.InvokeAsync(context)).Returns(Task.CompletedTask);
+            IPipelineRequest next = mockNext.Object;
+
+            string entryName = "New-Item.txt";
+            string entryContents = "Why are you still whining?";
+            string zipFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}{Path.DirectorySeparatorChar}Disney.zip";
+            int expectedEntryCount = 2;
+
+            using (var zipStream = new MemoryStream())
+            {
+                using (var fileStream = File.OpenRead(zipFilePath))
+                {
+                    await fileStream.CopyToAsync(zipStream).ConfigureAwait(false);
+                }
+
+                using (var zipArchive = new ZipArchive(zipStream, ZipArchiveMode.Update, true))
+                {
+                    using (var entryStream = new MemoryStream(Encoding.UTF8.GetBytes(entryContents)))
+                    {
+                        context.Items.Add(options.ZipArchiveContextName, zipArchive);
+                        context.Items.Add(options.ZipArchiveEntryNameContextName, entryName);
+                        context.Items.Add(options.OutputStreamContextName, entryStream);
+
+                        await using (var source = new AddZipArchiveEntryStep(logger, options, next))
+                        {
+                            // act
+                            await source.InvokeAsync(context).ConfigureAwait(false);
+                        }
+
+                        // assert
+                        if (context.Errors.Any())
+                        {
+                            throw context.Errors[0];
+                        }
+
+                        Assert.IsTrue(context.Items.ContainsKey(options.ZipArchiveContextName), "ZipArchive should exist in context.");
+                        Assert.AreEqual(zipArchive, context.Items[options.ZipArchiveContextName]);
+                        Assert.IsTrue(context.Items.ContainsKey(options.ZipArchiveEntryNameContextName), "ZipArchiveEntryName should exist in context.");
+                        Assert.AreEqual(entryName, context.Items[options.ZipArchiveEntryNameContextName]);
+                        Assert.IsTrue(context.Items.ContainsKey(options.OutputStreamContextName), "OutputStream should exist in context.");
+                        Assert.IsTrue((context.Items[options.OutputStreamContextName] as Stream).CanRead, "OutputStream should not be closed.");
                     }
                 }
 
@@ -257,12 +341,13 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
         {
             // arrange
             ILogger<AddZipArchiveEntryStep> logger = null;
+            var options = new AddZipArchiveEntryOptions();
             IPipelineRequest next = new Mock<IPipelineRequest>().Object;
 
             string expectedParamName = nameof(logger);
 
             // act
-            var result = Assert.ThrowsException<ArgumentNullException>(() => new AddZipArchiveEntryStep(logger, next));
+            var result = Assert.ThrowsException<ArgumentNullException>(() => new AddZipArchiveEntryStep(logger, options, next));
 
             // assert
             Assert.IsNotNull(result);
@@ -274,12 +359,31 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
         {
             // arrange
             ILogger<AddZipArchiveEntryStep> logger = new Mock<ILogger<AddZipArchiveEntryStep>>().Object;
+            var options = new AddZipArchiveEntryOptions();
             IPipelineRequest next = null;
 
             string expectedParamName = nameof(next);
 
             // act
-            var result = Assert.ThrowsException<ArgumentNullException>(() => new AddZipArchiveEntryStep(logger, next));
+            var result = Assert.ThrowsException<ArgumentNullException>(() => new AddZipArchiveEntryStep(logger, options, next));
+
+            // assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(expectedParamName, result.ParamName);
+        }
+
+        [TestMethod]
+        public void Throws_ArgumentNullException_From_Constructor_When_Options_Is_Null()
+        {
+            // arrange
+            ILogger<AddZipArchiveEntryStep> logger = new Mock<ILogger<AddZipArchiveEntryStep>>().Object;
+            AddZipArchiveEntryOptions options = null;
+            IPipelineRequest next = new Mock<IPipelineRequest>().Object;
+
+            string expectedParamName = nameof(options);
+
+            // act
+            var result = Assert.ThrowsException<ArgumentNullException>(() => new AddZipArchiveEntryStep(logger, options, next));
 
             // assert
             Assert.IsNotNull(result);
@@ -291,6 +395,7 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
         {
             // arrange
             ILogger<AddZipArchiveEntryStep> logger = new Mock<ILogger<AddZipArchiveEntryStep>>().Object;
+            var options = new AddZipArchiveEntryOptions();
             IPipelineRequest next = new Mock<IPipelineRequest>().Object;
 
             var context = new PipelineContext();
@@ -313,11 +418,11 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
                 {
                     using (var entryStream = new MemoryStream(Encoding.UTF8.GetBytes(entryContents)))
                     {
-                        context.Items.Add(CompressionConstants.ZIP_ARCHIVE, zipArchive);
-                        context.Items.Add(CompressionConstants.ZIP_ARCHIVE_ENTRY_NAME, entryName);
-                        context.Items.Add(PipelineContextConstants.OUTPUT_STREAM, entryStream);
+                        context.Items.Add(options.ZipArchiveContextName, zipArchive);
+                        context.Items.Add(options.ZipArchiveEntryNameContextName, entryName);
+                        context.Items.Add(options.OutputStreamContextName, entryStream);
 
-                        await using (var source = new AddZipArchiveEntryStep(logger, next))
+                        await using (var source = new AddZipArchiveEntryStep(logger, options, next))
                         {
                             // act
                             await source.InvokeAsync(context).ConfigureAwait(false);

--- a/Steps/IO/Compression/test/CloseZipArchiveStepTests.cs
+++ b/Steps/IO/Compression/test/CloseZipArchiveStepTests.cs
@@ -316,7 +316,7 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
             // arrange
             ILogger<CloseZipArchiveStep> logger = new Mock<ILogger<CloseZipArchiveStep>>().Object;
             CloseZipArchiveOptions options = null;
-            IPipelineRequest next = null;
+            IPipelineRequest next = new Mock<IPipelineRequest>().Object;
 
             string expectedParamName = nameof(options);
 

--- a/Steps/IO/Compression/test/RemoveZipArchiveEntryStepTests.cs
+++ b/Steps/IO/Compression/test/RemoveZipArchiveEntryStepTests.cs
@@ -211,7 +211,7 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
             IPipelineRequest next = mockNext.Object;
 
             string zipFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}{Path.DirectorySeparatorChar}Disney.zip";
-            int expectedEntryCount = 0;
+            int expectedEntryCount = 1;
 
             string missingEntryName = "Disney.txt.json";
 
@@ -355,7 +355,7 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
             // arrange
             ILogger<RemoveZipArchiveEntryStep> logger = new Mock<ILogger<RemoveZipArchiveEntryStep>>().Object;
             RemoveZipArchiveEntryOptions options = null;
-            IPipelineRequest next = null;
+            IPipelineRequest next = new Mock<IPipelineRequest>().Object;
 
             string expectedParamName = nameof(options);
 

--- a/Steps/IO/Compression/test/UpdateZipArchiveEntryStepTests.cs
+++ b/Steps/IO/Compression/test/UpdateZipArchiveEntryStepTests.cs
@@ -390,7 +390,7 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
             // arrange
             ILogger<UpdateZipArchiveEntryStep> logger = new Mock<ILogger<UpdateZipArchiveEntryStep>>().Object;
             UpdateZipArchiveEntryOptions options = null;
-            IPipelineRequest next = null;
+            IPipelineRequest next = new Mock<IPipelineRequest>().Object;
 
             string expectedParamName = nameof(options);
 

--- a/Steps/IO/Compression/test/UpdateZipArchiveEntryStepTests.cs
+++ b/Steps/IO/Compression/test/UpdateZipArchiveEntryStepTests.cs
@@ -49,10 +49,11 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
         {
             // arrange
             var logger = new Mock<ILogger<UpdateZipArchiveEntryStep>>().Object;
+            var options = new UpdateZipArchiveEntryOptions();
             var next = new Mock<IPipelineRequest>().Object;
 
             // act
-            await using (var result = new UpdateZipArchiveEntryStep(logger, next))
+            await using (var result = new UpdateZipArchiveEntryStep(logger, options, next))
             {
                 // assert
                 Assert.IsNotNull(result);
@@ -68,6 +69,7 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
             var context = new PipelineContext();
 
             var logger = new Mock<ILogger<UpdateZipArchiveEntryStep>>().Object;
+            var options = new UpdateZipArchiveEntryOptions();
             var next = new Mock<IPipelineRequest>().Object;
 
             string entryName = "Disney.txt";
@@ -75,7 +77,7 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
             string zipFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}{Path.DirectorySeparatorChar}Disney.zip";
 
             int expectedErrorCount = 1;
-            string expectedMessage = Pipelines.Resources.NO_KEY_IN_CONTEXT(CultureInfo.CurrentCulture, PipelineContextConstants.OUTPUT_STREAM);
+            string expectedMessage = Pipelines.Resources.NO_KEY_IN_CONTEXT(CultureInfo.CurrentCulture, options.OutputStreamContextName);
 
             using (var zipStream = new MemoryStream())
             {
@@ -88,10 +90,10 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
                 {
                     using (var entryStream = new MemoryStream(Encoding.UTF8.GetBytes(entryContents)))
                     {
-                        context.Items.Add(CompressionConstants.ZIP_ARCHIVE, zipArchive);
-                        context.Items.Add(CompressionConstants.ZIP_ARCHIVE_ENTRY_NAME, entryName);
+                        context.Items.Add(options.ZipArchiveContextName, zipArchive);
+                        context.Items.Add(options.ZipArchiveEntryNameContextName, entryName);
 
-                        await using (var source = new UpdateZipArchiveEntryStep(logger, next))
+                        await using (var source = new UpdateZipArchiveEntryStep(logger, options, next))
                         {
                             // act
                             await source.InvokeAsync(context).ConfigureAwait(false);
@@ -113,6 +115,7 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
             var context = new PipelineContext();
 
             var logger = new Mock<ILogger<UpdateZipArchiveEntryStep>>().Object;
+            var options = new UpdateZipArchiveEntryOptions();
             var next = new Mock<IPipelineRequest>().Object;
 
             string entryName = "Disney.txt";
@@ -120,7 +123,7 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
             string zipFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}{Path.DirectorySeparatorChar}Disney.zip";
 
             int expectedErrorCount = 1;
-            string expectedMessage = Pipelines.Resources.NO_KEY_IN_CONTEXT(CultureInfo.CurrentCulture, CompressionConstants.ZIP_ARCHIVE);
+            string expectedMessage = Pipelines.Resources.NO_KEY_IN_CONTEXT(CultureInfo.CurrentCulture, options.ZipArchiveContextName);
 
             using (var zipStream = new MemoryStream())
             {
@@ -133,10 +136,10 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
                 {
                     using (var entryStream = new MemoryStream(Encoding.UTF8.GetBytes(entryContents)))
                     {
-                        context.Items.Add(CompressionConstants.ZIP_ARCHIVE_ENTRY_NAME, entryName);
-                        context.Items.Add(PipelineContextConstants.OUTPUT_STREAM, entryStream);
+                        context.Items.Add(options.ZipArchiveEntryNameContextName, entryName);
+                        context.Items.Add(options.OutputStreamContextName, entryStream);
 
-                        await using (var source = new UpdateZipArchiveEntryStep(logger, next))
+                        await using (var source = new UpdateZipArchiveEntryStep(logger, options, next))
                         {
                             // act
                             await source.InvokeAsync(context).ConfigureAwait(false);
@@ -158,13 +161,14 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
             var context = new PipelineContext();
 
             var logger = new Mock<ILogger<UpdateZipArchiveEntryStep>>().Object;
+            var options = new UpdateZipArchiveEntryOptions();
             var next = new Mock<IPipelineRequest>().Object;
 
             string entryContents = "Why are you still whining?";
             string zipFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}{Path.DirectorySeparatorChar}Disney.zip";
 
             int expectedErrorCount = 1;
-            string expectedMessage = Pipelines.Resources.NO_KEY_IN_CONTEXT(CultureInfo.CurrentCulture, CompressionConstants.ZIP_ARCHIVE_ENTRY_NAME);
+            string expectedMessage = Pipelines.Resources.NO_KEY_IN_CONTEXT(CultureInfo.CurrentCulture, options.ZipArchiveEntryNameContextName);
 
             using (var zipStream = new MemoryStream())
             {
@@ -177,10 +181,10 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
                 {
                     using (var entryStream = new MemoryStream(Encoding.UTF8.GetBytes(entryContents)))
                     {
-                        context.Items.Add(CompressionConstants.ZIP_ARCHIVE, zipArchive);
-                        context.Items.Add(PipelineContextConstants.OUTPUT_STREAM, entryStream);
+                        context.Items.Add(options.ZipArchiveContextName, zipArchive);
+                        context.Items.Add(options.OutputStreamContextName, entryStream);
 
-                        await using (var source = new UpdateZipArchiveEntryStep(logger, next))
+                        await using (var source = new UpdateZipArchiveEntryStep(logger, options, next))
                         {
                             // act
                             await source.InvokeAsync(context).ConfigureAwait(false);
@@ -203,6 +207,8 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
 
             ILogger<UpdateZipArchiveEntryStep> logger = new Mock<ILogger<UpdateZipArchiveEntryStep>>().Object;
 
+            var options = new UpdateZipArchiveEntryOptions();
+
             var mockNext = new Mock<IPipelineRequest>();
             mockNext.Setup(x => x.InvokeAsync(context)).Returns(Task.CompletedTask);
             IPipelineRequest next = mockNext.Object;
@@ -223,11 +229,11 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
                 {
                     using (var entryStream = new MemoryStream(Encoding.UTF8.GetBytes(entryContents)))
                     {
-                        context.Items.Add(CompressionConstants.ZIP_ARCHIVE, zipArchive);
-                        context.Items.Add(CompressionConstants.ZIP_ARCHIVE_ENTRY_NAME, entryName);
-                        context.Items.Add(PipelineContextConstants.OUTPUT_STREAM, entryStream);
+                        context.Items.Add(options.ZipArchiveContextName, zipArchive);
+                        context.Items.Add(options.ZipArchiveEntryNameContextName, entryName);
+                        context.Items.Add(options.OutputStreamContextName, entryStream);
 
-                        await using (var source = new UpdateZipArchiveEntryStep(logger, next))
+                        await using (var source = new UpdateZipArchiveEntryStep(logger, options, next))
                         {
                             // act
                             await source.InvokeAsync(context).ConfigureAwait(false);
@@ -239,12 +245,89 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
                             throw context.Errors[0];
                         }
 
-                        Assert.IsTrue(context.Items.ContainsKey(CompressionConstants.ZIP_ARCHIVE), "ZipArchive should exist in context.");
-                        Assert.AreEqual(zipArchive, context.Items[CompressionConstants.ZIP_ARCHIVE]);
-                        Assert.IsTrue(context.Items.ContainsKey(CompressionConstants.ZIP_ARCHIVE_ENTRY_NAME), "ZipArchiveEntryName should exist in context.");
-                        Assert.AreEqual(entryName, context.Items[CompressionConstants.ZIP_ARCHIVE_ENTRY_NAME]);
-                        Assert.IsTrue(context.Items.ContainsKey(PipelineContextConstants.OUTPUT_STREAM), "OutputStream should exist in context.");
-                        Assert.IsTrue((context.Items[PipelineContextConstants.OUTPUT_STREAM] as Stream).CanRead, "OutputStream should not be closed.");
+                        Assert.IsTrue(context.Items.ContainsKey(options.ZipArchiveContextName), "ZipArchive should exist in context.");
+                        Assert.AreEqual(zipArchive, context.Items[options.ZipArchiveContextName]);
+                        Assert.IsTrue(context.Items.ContainsKey(options.ZipArchiveEntryNameContextName), "ZipArchiveEntryName should exist in context.");
+                        Assert.AreEqual(entryName, context.Items[options.ZipArchiveEntryNameContextName]);
+                        Assert.IsTrue(context.Items.ContainsKey(options.OutputStreamContextName), "OutputStream should exist in context.");
+                        Assert.IsTrue((context.Items[options.OutputStreamContextName] as Stream).CanRead, "OutputStream should not be closed.");
+                    }
+                }
+
+                // assert that ZipArchive is usable and the update was accepted.
+                zipStream.Position = 0;
+                using (var assertArchive = new ZipArchive(zipStream))
+                {
+                    Assert.AreEqual(expectedEntryCount, assertArchive.Entries.Count);
+                    var assertEntry = assertArchive.GetEntry(entryName);
+                    using (var assertEntryStream = assertEntry.Open())
+                    {
+                        using (var reader = new StreamReader(assertEntryStream, leaveOpen: true))
+                        {
+                            Assert.AreEqual(entryContents, await reader.ReadToEndAsync().ConfigureAwait(false));
+                        }
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task Returns_ZipArchive_From_InvokeAsync_When_Options_Uses_Different_ContextNames()
+        {
+            // arrange
+            var context = new PipelineContext();
+
+            ILogger<UpdateZipArchiveEntryStep> logger = new Mock<ILogger<UpdateZipArchiveEntryStep>>().Object;
+
+            var options = new UpdateZipArchiveEntryOptions()
+            {
+                OutputStreamContextName = "OUTPUT_STREAM_TESTING",
+                ZipArchiveContextName = "ZIP_ARCHIVE_TESTING",
+                ZipArchiveEntryNameContextName = "ZIP_ARCHIVE_ENTRY_NAME"
+            };
+
+            var mockNext = new Mock<IPipelineRequest>();
+            mockNext.Setup(x => x.InvokeAsync(context)).Returns(Task.CompletedTask);
+            IPipelineRequest next = mockNext.Object;
+
+            string entryName = "Disney.txt";
+            string entryContents = "Why are you still whining?";
+            string zipFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}{Path.DirectorySeparatorChar}Disney.zip";
+            int expectedEntryCount = 1;
+
+            using (var zipStream = new MemoryStream())
+            {
+                using (var fileStream = File.OpenRead(zipFilePath))
+                {
+                    await fileStream.CopyToAsync(zipStream).ConfigureAwait(false);
+                }
+
+                using (var zipArchive = new ZipArchive(zipStream, ZipArchiveMode.Update, true))
+                {
+                    using (var entryStream = new MemoryStream(Encoding.UTF8.GetBytes(entryContents)))
+                    {
+                        context.Items.Add(options.ZipArchiveContextName, zipArchive);
+                        context.Items.Add(options.ZipArchiveEntryNameContextName, entryName);
+                        context.Items.Add(options.OutputStreamContextName, entryStream);
+
+                        await using (var source = new UpdateZipArchiveEntryStep(logger, options, next))
+                        {
+                            // act
+                            await source.InvokeAsync(context).ConfigureAwait(false);
+                        }
+
+                        // assert
+                        if (context.Errors.Any())
+                        {
+                            throw context.Errors[0];
+                        }
+
+                        Assert.IsTrue(context.Items.ContainsKey(options.ZipArchiveContextName), "ZipArchive should exist in context.");
+                        Assert.AreEqual(zipArchive, context.Items[options.ZipArchiveContextName]);
+                        Assert.IsTrue(context.Items.ContainsKey(options.ZipArchiveEntryNameContextName), "ZipArchiveEntryName should exist in context.");
+                        Assert.AreEqual(entryName, context.Items[options.ZipArchiveEntryNameContextName]);
+                        Assert.IsTrue(context.Items.ContainsKey(options.OutputStreamContextName), "OutputStream should exist in context.");
+                        Assert.IsTrue((context.Items[options.OutputStreamContextName] as Stream).CanRead, "OutputStream should not be closed.");
                     }
                 }
 
@@ -270,12 +353,13 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
         {
             // arrange
             ILogger<UpdateZipArchiveEntryStep> logger = null;
+            var options = new UpdateZipArchiveEntryOptions();
             IPipelineRequest next = new Mock<IPipelineRequest>().Object;
 
             string expectedParamName = nameof(logger);
 
             // act
-            var result = Assert.ThrowsException<ArgumentNullException>(() => new UpdateZipArchiveEntryStep(logger, next));
+            var result = Assert.ThrowsException<ArgumentNullException>(() => new UpdateZipArchiveEntryStep(logger, options, next));
 
             // assert
             Assert.IsNotNull(result);
@@ -287,12 +371,31 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
         {
             // arrange
             ILogger<UpdateZipArchiveEntryStep> logger = new Mock<ILogger<UpdateZipArchiveEntryStep>>().Object;
+            var options = new UpdateZipArchiveEntryOptions();
             IPipelineRequest next = null;
 
             string expectedParamName = nameof(next);
 
             // act
-            var result = Assert.ThrowsException<ArgumentNullException>(() => new UpdateZipArchiveEntryStep(logger, next));
+            var result = Assert.ThrowsException<ArgumentNullException>(() => new UpdateZipArchiveEntryStep(logger, options, next));
+
+            // assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(expectedParamName, result.ParamName);
+        }
+
+        [TestMethod]
+        public void Throws_ArgumentNullException_From_Constructor_When_Options_Is_Null()
+        {
+            // arrange
+            ILogger<UpdateZipArchiveEntryStep> logger = new Mock<ILogger<UpdateZipArchiveEntryStep>>().Object;
+            UpdateZipArchiveEntryOptions options = null;
+            IPipelineRequest next = null;
+
+            string expectedParamName = nameof(options);
+
+            // act
+            var result = Assert.ThrowsException<ArgumentNullException>(() => new UpdateZipArchiveEntryStep(logger, options, next));
 
             // assert
             Assert.IsNotNull(result);
@@ -304,6 +407,7 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
         {
             // arrange
             ILogger<UpdateZipArchiveEntryStep> logger = new Mock<ILogger<UpdateZipArchiveEntryStep>>().Object;
+            var options = new UpdateZipArchiveEntryOptions();
             IPipelineRequest next = new Mock<IPipelineRequest>().Object;
 
             var context = new PipelineContext();
@@ -326,11 +430,11 @@ namespace MyTrout.Pipelines.IO.Compression.Tests
                 {
                     using (var entryStream = new MemoryStream(Encoding.UTF8.GetBytes(entryContents)))
                     {
-                        context.Items.Add(CompressionConstants.ZIP_ARCHIVE, zipArchive);
-                        context.Items.Add(CompressionConstants.ZIP_ARCHIVE_ENTRY_NAME, entryName);
-                        context.Items.Add(PipelineContextConstants.OUTPUT_STREAM, entryStream);
+                        context.Items.Add(options.ZipArchiveContextName, zipArchive);
+                        context.Items.Add(options.ZipArchiveEntryNameContextName, entryName);
+                        context.Items.Add(options.OutputStreamContextName, entryStream);
 
-                        await using (var source = new UpdateZipArchiveEntryStep(logger, next))
+                        await using (var source = new UpdateZipArchiveEntryStep(logger, options, next))
                         {
                             // act
                             await source.InvokeAsync(context).ConfigureAwait(false);


### PR DESCRIPTION
## BREAKING CHANGES:
- [#160](https://github.com/mytrout/Pipelines/issues/160) Remove support for .NET 5.0. 
- [#162](https://github.com/mytrout/Pipelines/issues/162) Upgrade to MyTrout.Pipelines 4.0.0 
- [#161](https://github.com/mytrout/Pipelines/issues/161) Refactor all ~Step and ~Options to use user-configurable context names for any value read from or written to IPipelineContext.Items.
- [#161](https://github.com/mytrout/Pipelines/issues/161) Add additional unit test to test that ContextName values are used when Steps executes.
## NON-BREAKING CHANGES:
- [#160](https://github.com/mytrout/Pipelines/issues/160) Add support for .NET 7.0
- [#148](https://github.com/mytrout/Pipelines/issues/148) Refactor ~Step to use AbstractCachingPipelineStep<TStep, TOptions> to guarantee that existing INPUT_STREAM values are restored after execution of this step.
- [#148](https://github.com/mytrout/Pipelines/issues/148) Add additional unit test to ensure that ~Step restores PipelineContext.Items to its original state after execution.
- Move parameter and PipelineContext.Items validation to the InvokeBeforeCacheAsync() method for classes implementing AbstractCachingPipelineStep&lt;TStep&gt;
- Add .editorconfig to enforce rules in Visual Studio 2022.
- Update Microsoft.CodeAnalysis.NetAnalyzers to .NET 7.0 preview version to eliminate build warnings.
- Update Microsoft.CodeAnalysis.Analyzers to .NET 7.0 preview version to eliminate build warnings.
- Update Microsoft.VisualStudio.ThreadingAnalyzers to 17.2.32
- Upgrade SonarAnalyzer.CSharp 8.40.0.48530
- Upgrade StyleCop.Analyzers to 1.2.0-beta.435
- Remove pramga lines in favor of null-forgiving operators and an explanation comment.