### PR TITLE
Update Pipelines.Core to 4.0.2 to handle SonarCloud information publi…

### DIFF
--- a/.github/workflows/build-pipelines-core.yaml
+++ b/.github/workflows/build-pipelines-core.yaml
@@ -36,7 +36,7 @@ jobs:
         PIPELINE_PreventCollisionsWithRenamedValueNames: "true"
         
         # This value should change on each deployable version of this solution.
-        PROJECT_VERSION: '4.0.1'
+        PROJECT_VERSION: '4.0.2'
         
     steps:
       - name: Checkout the Source
@@ -102,11 +102,11 @@ jobs:
           if-no-files-found: error
         if: "github.ref == 'refs/heads/main' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
         
-      - name: Publish the package to nuget.org
-        run: dotnet nuget push "../Pipelines/Core/src/bin/Release/*.nupkg" --api-key ${{ secrets.MYTROUT_NUGET_API_KEY }} --source "https://api.nuget.org/v3/index.json" --skip-duplicate
-        if: "github.ref == 'refs/heads/main' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
+      #- name: Publish the package to nuget.org
+      #  run: dotnet nuget push "../Pipelines/Core/src/bin/Release/*.nupkg" --api-key ${{ secrets.MYTROUT_NUGET_API_KEY }} --source "https://api.nuget.org/v3/index.json" --skip-duplicate
+      #  if: "github.ref == 'refs/heads/main' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
 
-      - name: Publish the package to GitHub.
-        run: dotnet nuget push "../Pipelines/Core/src/bin/Release/*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/mytrout/index.json" --skip-duplicate
-        if: "github.ref == 'refs/heads/main' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
+      #- name: Publish the package to GitHub.
+      #  run: dotnet nuget push "../Pipelines/Core/src/bin/Release/*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/mytrout/index.json" --skip-duplicate
+      #  if: "github.ref == 'refs/heads/main' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
  

--- a/Core/changelog.md
+++ b/Core/changelog.md
@@ -1,5 +1,10 @@
 # MyTrout.Pipelines.Core Change Log
 
+## 4.0.2 - SONARCLOUD UPDATE ONLY
+- Rebuild with a new version number after renaming the master branch in SonarCloud.
+- Prevent the publish to nuget.org as it isn't necessary.
+- NOTE TO DEVELOPERS: Developers must reverse the removal of nuget and github publishing when the next version is ready to be released.
+
 ## 4.0.1
 - Add PipelineContextValidationExtension to check object existence without casting it.
 - Add new step MoveInputObjectToOutputObjectStep to perform default renaming easily.


### PR DESCRIPTION
Update Pipelines.Core to 4.0.2 to handle SonarCloud information publishing and main branch rename.