### PR TITLE
Make SendHttpRequestStep work with .NET 6.0 C# endpoints.

### DIFF
--- a/.github/workflows/build-pipelines-steps-communications-http.yaml
+++ b/.github/workflows/build-pipelines-steps-communications-http.yaml
@@ -4,7 +4,7 @@ name: MyTrout.Pipelines.Steps.Communications.Http
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - '.github/workflows/build-pipelines-steps-communications-http.yaml'
       - '**/Pipelines/Steps/Communications/Http/**/*.*'
@@ -34,7 +34,7 @@ jobs:
         SOLUTION_NAME: 'MyTrout.Pipelines.Steps.Communications.Http.sln'
         
         # This value should change on each deployable version of this solution.
-        PROJECT_VERSION: '2.0.0'
+        PROJECT_VERSION: '3.0.0'
         
         # These values are used for unit and integration testing
         PIPELINE_TEST_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -96,12 +96,12 @@ jobs:
           name: nupkg
           path: ${{ env.WORKING_DIRECTORY }}/**/bin/Release/*.nupkg
           if-no-files-found: error
-        if: "github.ref == 'refs/heads/master' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
+        if: "github.ref == 'refs/heads/main' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
         
       - name: Publish the package to nuget.org.
         run: dotnet nuget push "${{ env.WORKING_DIRECTORY }}/src/bin/Release/*.nupkg" --api-key ${{ secrets.MYTROUT_NUGET_API_KEY }} --source "https://api.nuget.org/v3/index.json" --skip-duplicate
-        if: "github.ref == 'refs/heads/master' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
+        if: "github.ref == 'refs/heads/main' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
 
       - name: Publish the package to GitHub.
         run: dotnet nuget push "${{ env.WORKING_DIRECTORY }}/src/bin/Release/*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/mytrout/index.json" --skip-duplicate
-        if: "github.ref == 'refs/heads/master' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
+        if: "github.ref == 'refs/heads/main' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"

--- a/Steps/Communications/Http/changelog.md
+++ b/Steps/Communications/Http/changelog.md
@@ -1,5 +1,17 @@
 # MyTrout.Pipelines.Steps.Communications.Http Change Log
 
+## 3.0.0
+- The SendHttpRequestStep did not work properly for Microsoft .NET 6.0 delivered C# websites prior to this change.
+### BREAKING CHANGES:
+- Change the type on SendHttpRequestOptions.HttpMethod from HttpMethod to string to allow IConfiguration to set the value.
+- Change unit tests to reflect the change in HttpMethod.
+### NON-BREAKING CHANGES:
+- Change the push branch in the build yaml from master to main.
+- Upgrade to MyTrout.Pipelines 4.0.1
+- Add Content-Type header value on the HttpRequestMessage.Content element when uploading content.
+- Set a default value of "POST" on SendHttpRequestOptions.HttpMethod
+- [#198](https://github.com/mytrout/Pipelines/issues/198) Allow context values to be injected dynamically into the HttpEndpoint to allow GET verbs to use query string values.
+
 ## 2.0.0
 ### BREAKING CHANGES:
 - [#160](https://github.com/mytrout/Pipelines/issues/160) Remove support for .NET 5.0. 

--- a/Steps/Communications/Http/src/MyTrout.Pipelines.Steps.Communications.Http.csproj
+++ b/Steps/Communications/Http/src/MyTrout.Pipelines.Steps.Communications.Http.csproj
@@ -46,7 +46,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MyTrout.Pipelines" Version="[4,5)" />
+    <PackageReference Include="MyTrout.Pipelines" Version="[4.0.1,5)" />
     <PackageReference Include="Roslynator.Analyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Steps/Communications/Http/src/SendHttpRequestOptions.cs
+++ b/Steps/Communications/Http/src/SendHttpRequestOptions.cs
@@ -1,7 +1,7 @@
 ﻿// <copyright file="SendHttpRequestOptions.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2021 Chris Trout
+// Copyright(c) 2021-2022 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,6 +24,7 @@
 
 namespace MyTrout.Pipelines.Steps.Communications.Http
 {
+    using Microsoft.Extensions.Configuration;
     using MyTrout.Pipelines.Core;
     using System;
     using System.Collections.Generic;
@@ -40,9 +41,14 @@ namespace MyTrout.Pipelines.Steps.Communications.Http
     public class SendHttpRequestOptions
     {
         /// <summary>
+        /// Gets or sets the HTTP Content-Type Content Header that is specified when <see cref="UploadInputStreamAsContent"/> is <see langword="true"/>.
+        /// </summary>
+        public string ContentTypeHeaderValue { get; set; } = "application/json";
+
+        /// <summary>
         /// Gets or sets the HTTP Headers from <see cref="IPipelineContext.Items"/> that need to be set for the <see cref="HttpEndpoint" /> to work.
         /// </summary>
-        public IEnumerable<string> HeaderNames { get; set; } = new List<string>();
+        public List<string> HeaderNames { get; set; } = new List<string>();
 
 #pragma warning disable CS8618 // HttpClient and HttpEndpoint should always be set in options.
         /// <summary>
@@ -88,9 +94,14 @@ namespace MyTrout.Pipelines.Steps.Communications.Http
         public string IsSuccessfulStatusCodeContextName { get; set; } = HttpCommunicationConstants.HTTP_IS_SUCCESSFUL_STATUS_CODE;
 
         /// <summary>
-        /// Gets or sets the method for the Htto Endpoint call.
+        /// Gets or sets the HTTP Method value from <see cref="IConfiguration"/>.
         /// </summary>
-        public HttpMethod Method { get; set; } = HttpMethod.Post;
+        public string HttpMethod { get; set; } = "POST";
+
+        /// <summary>
+        /// Gets or sets a list of values that will be replaced in the <see cref="HttpEndpoint"/> from the <see cref="IPipelineContext"/>.
+        /// </summary>
+        public List<string> HttpEndpointReplacementKeys { get; set; } = new List<string>();
 
         /// <summary>
         /// Gets or sets the Output Stream Context Name used for <see cref="IPipelineContext.Items"/>.

--- a/Steps/Communications/Http/test/MyTrout.Pipelines.Steps.Communications.Http.Tests/SendHttpRequestStepTests.cs
+++ b/Steps/Communications/Http/test/MyTrout.Pipelines.Steps.Communications.Http.Tests/SendHttpRequestStepTests.cs
@@ -1,7 +1,7 @@
 // <copyright file="SendHttpRequestStep.cs" company="Chris Trout">
 // MIT License
 //
-// Copyright(c) 2021 Chris Trout
+// Copyright(c) 2021-2022 Chris Trout
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -55,7 +55,7 @@ namespace MyTrout.Pipelines.Steps.Communications.Http.Tests
             // arrange
             var logger = new Mock<ILogger<SendHttpRequestStep>>().Object;
             var options = new SendHttpRequestOptions();
-            
+
             var next = new Mock<IPipelineRequest>().Object;
 
             // act
@@ -69,7 +69,7 @@ namespace MyTrout.Pipelines.Steps.Communications.Http.Tests
             }
         }
 
-        
+
         [TestMethod]
         public async Task Returns_Failed_Response_From_Fake_HTTP_GET_Request_When_ReasonPhrase_Is_Null()
         {
@@ -81,7 +81,7 @@ namespace MyTrout.Pipelines.Steps.Communications.Http.Tests
                 {
                     HttpClient = httpClient,
                     HttpEndpoint = new Uri("https://swapi.dev/api/"),
-                    Method = System.Net.Http.HttpMethod.Get
+                    HttpMethod = "GET"
                 };
 
                 string expectedResult = string.Empty;
@@ -133,7 +133,7 @@ namespace MyTrout.Pipelines.Steps.Communications.Http.Tests
                 {
                     HttpClient = httpClient,
                     HttpEndpoint = new Uri("https://swapi.dev/api/"),
-                    Method = System.Net.Http.HttpMethod.Get
+                    HttpMethod = "GET"
                 };
 
                 string expectedResult = "{\"people\":\"https://swapi.dev/api/people/\",\"planets\":\"https://swapi.dev/api/planets/\",\"films\":\"https://swapi.dev/api/films/\",\"species\":\"https://swapi.dev/api/species/\",\"vehicles\":\"https://swapi.dev/api/vehicles/\",\"starships\":\"https://swapi.dev/api/starships/\"}";
@@ -185,7 +185,7 @@ namespace MyTrout.Pipelines.Steps.Communications.Http.Tests
                     HeaderNames = new List<string>() { "Accepted" },
                     HttpClient = httpClient,
                     HttpEndpoint = new Uri("https://swapi.dev/api/"),
-                    Method = System.Net.Http.HttpMethod.Get
+                    HttpMethod = "GET"
                 };
 
                 string expectedResult = "{\"people\":\"https://swapi.dev/api/people/\",\"planets\":\"https://swapi.dev/api/planets/\",\"films\":\"https://swapi.dev/api/films/\",\"species\":\"https://swapi.dev/api/species/\",\"vehicles\":\"https://swapi.dev/api/vehicles/\",\"starships\":\"https://swapi.dev/api/starships/\"}";
@@ -231,14 +231,14 @@ namespace MyTrout.Pipelines.Steps.Communications.Http.Tests
             // arrange
             var logger = new Mock<ILogger<SendHttpRequestStep>>().Object;
             var requestOptions = new HttpRequestOptions();
-            requestOptions.TryAdd("Accept", "aaplication/json");
+            requestOptions.TryAdd("Accept", "application/json");
             using (var httpClient = new HttpClient())
             {
                 var options = new SendHttpRequestOptions()
                 {
                     HttpClient = httpClient,
                     HttpEndpoint = new Uri("https://swapi.dev/api/"),
-                    Method = System.Net.Http.HttpMethod.Get,
+                    HttpMethod = "GET",
                     RequestOptions = requestOptions
                 };
 
@@ -275,7 +275,60 @@ namespace MyTrout.Pipelines.Steps.Communications.Http.Tests
                 Assert.AreEqual(0, context.Errors.Count);
             }
         }
-        
+
+        [TestMethod]
+        public async Task Returns_Successful_Response_From_HTTP_GET_Request_When_HttpEndpointReplacementKeys_Are_Set()
+        {
+            // arrange
+            var logger = new Mock<ILogger<SendHttpRequestStep>>().Object;
+            var requestOptions = new HttpRequestOptions();
+            requestOptions.TryAdd("Accept", "application/json");
+            using (var httpClient = new HttpClient())
+            {
+                var options = new SendHttpRequestOptions()
+                {
+                    HttpClient = httpClient,
+                    HttpEndpoint = new Uri("https://swapi.dev/api/people/peopleId/"),
+                    HttpEndpointReplacementKeys = new List<string>() { "peopleId" },
+                    HttpMethod = "GET",
+                    RequestOptions = requestOptions
+                };
+
+                string expectedResult = "{\"name\":\"Luke Skywalker\",";
+
+                var mockNext = new Mock<IPipelineRequest>();
+                mockNext.Setup(x => x.InvokeAsync(It.IsAny<PipelineContext>())).Callback((IPipelineContext context) =>
+                {
+                    using (var reader = new StreamReader(context.Items[PipelineContextConstants.OUTPUT_STREAM] as Stream))
+                    {
+                        string result = reader.ReadToEnd();
+
+                        // assert
+                        Assert.AreEqual(HttpStatusCode.OK, context.Items[HttpCommunicationConstants.HTTP_STATUS_CODE]);
+                        Assert.IsTrue(context.Items.ContainsKey(HttpCommunicationConstants.HTTP_IS_SUCCESSFUL_STATUS_CODE) && ((bool)context.Items[HttpCommunicationConstants.HTTP_IS_SUCCESSFUL_STATUS_CODE]));
+                        Assert.AreEqual("OK", context.Items[HttpCommunicationConstants.HTTP_REASON_PHRASE]);
+                        Assert.IsTrue(context.Items.ContainsKey(HttpCommunicationConstants.HTTP_RESPONSE_HEADERS));
+                        Assert.IsTrue(context.Items.ContainsKey(HttpCommunicationConstants.HTTP_RESPONSE_TRAILING_HEADERS));
+                        StringAssert.StartsWith(result, expectedResult);
+                    }
+                });
+
+                var next = mockNext.Object;
+
+                var context = new PipelineContext();
+                context.Items.Add("peopleId", 1);
+
+                using (var step = new SendHttpRequestStep(logger, options, next))
+                {
+                    // act
+                    await step.InvokeAsync(context);
+                }
+
+                // assert - Phase 2
+                Assert.AreEqual(0, context.Errors.Count);
+            }
+        }
+        //GET 
         [TestMethod]
         public async Task Returns_Successful_Response_From_HTTP_POST_Request_When_Authentication_Is_Required()
         {
@@ -285,9 +338,10 @@ namespace MyTrout.Pipelines.Steps.Communications.Http.Tests
             {
                 var options = new SendHttpRequestOptions()
                 {
+                    ContentTypeHeaderValue = "application/graphql",
                     HttpClient = httpClient,
                     HttpEndpoint = new Uri("https://api.github.com/graphql"),
-                    Method = System.Net.Http.HttpMethod.Post,
+                    HttpMethod = "POST",
                     HeaderNames = new List<string>() { "Accept", "Authorization", "User-Agent" },
                     UploadInputStreamAsContent = true
                 };
@@ -352,6 +406,7 @@ namespace MyTrout.Pipelines.Steps.Communications.Http.Tests
             {
                 var options = new SendHttpRequestOptions()
                 {
+                    ContentTypeHeaderValue = "application/graphql",
                     HttpClient = httpClient,
                     HttpReasonPhraseContextName = "TESTING_REASON_PHRASE",
                     HttpResponseHeadersContextName = "TESTING_RESPONSE_HEADERS",
@@ -360,7 +415,7 @@ namespace MyTrout.Pipelines.Steps.Communications.Http.Tests
                     HttpEndpoint = new Uri("https://api.github.com/graphql"),
                     InputStreamContextName = "TESTING_INPUT_STREAM",
                     IsSuccessfulStatusCodeContextName = "TESTING_IS_SUCCESSFUL_RESPONSE_CODE",
-                    Method = System.Net.Http.HttpMethod.Post,
+                    HttpMethod = "POST",
                     HeaderNames = new List<string>() { "Accept", "Authorization", "User-Agent" },
                     OutputStreamContextName = "TESTING_OUTPUT_STREAM",
                     UploadInputStreamAsContent = true
@@ -428,7 +483,7 @@ namespace MyTrout.Pipelines.Steps.Communications.Http.Tests
                 {
                     HttpClient = httpClient,
                     HttpEndpoint = new Uri("https://swapi.dev/api/"),
-                    Method = System.Net.Http.HttpMethod.Get
+                    HttpMethod = "GET"
                 };
 
                 var mockNext = new Mock<IPipelineRequest>();
@@ -475,7 +530,7 @@ namespace MyTrout.Pipelines.Steps.Communications.Http.Tests
         public void Throws_ArgumentNullException_From_Constructor_When_Next_Is_Null()
         {
             // arrange
-            
+
             ILogger<SendHttpRequestStep> logger = new Mock<ILogger<SendHttpRequestStep>>().Object;
             var options = new SendHttpRequestOptions();
             IPipelineRequest next = null;
@@ -484,8 +539,8 @@ namespace MyTrout.Pipelines.Steps.Communications.Http.Tests
 
             // act
             var result = Assert.ThrowsException<ArgumentNullException>(() => new SendHttpRequestStep(logger, options, next));
-            
-            
+
+
             // assert
             Assert.IsNotNull(result);
             Assert.AreEqual(expectedParamName, result.ParamName);


### PR DESCRIPTION
- Make SendHttpRequestStep work with .NET 6.0 C# endpoints.
- Allow uri to have replaceable parameters.