### PR TITLE
Upgrade Core to .NET 8.0

### DIFF
--- a/.github/workflows/build-pipelines-core.yaml
+++ b/.github/workflows/build-pipelines-core.yaml
@@ -24,6 +24,6 @@ jobs:
       sonar-project-name: 'Pipelines.Core'
       working-directory: '/Core'
       solution-name: 'MyTrout.Pipelines.Core.sln'
-      project-version: '4.1.0'
+      project-version: '4.2.0'
     secrets: inherit
     

--- a/.github/workflows/build-pipelines-core.yaml
+++ b/.github/workflows/build-pipelines-core.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build:
-    uses: './.github/workflows/template-build-pipelines.yaml'
+    uses: './.github/workflows/template-build-pipelines-with-net-6-7-8.yaml'
     with:
       sonar-project-name: 'Pipelines.Core'
       working-directory: '/Core'

--- a/.github/workflows/template-build-pipelines-with-net-6-7-8.yaml
+++ b/.github/workflows/template-build-pipelines-with-net-6-7-8.yaml
@@ -64,12 +64,12 @@ jobs:
             7.0.x
             8.0.x
       
-      # "dotnet sonarscanner end" now requires Java 11 to be installed.
-      - name: Setup Java 11 for SonarQube.
+      # "dotnet sonarscanner end" now requires Java 17 to be installed.
+      - name: Setup Java 17 for SonarQube.
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: '11'
+          java-version: '17'
         if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
           
       # https://stackoverflow.com/questions/67597824/sonarscanner-for-net-fails-in-github-actions-net-5

--- a/.github/workflows/template-build-pipelines-with-net-6-7-8.yaml
+++ b/.github/workflows/template-build-pipelines-with-net-6-7-8.yaml
@@ -1,0 +1,130 @@
+name: MyTrout.Pipelines.Build.Template
+
+on:
+  workflow_call:
+    inputs:
+      sonar-project-name:
+        required: true
+        type: string
+      working-directory:
+        required: true
+        type: string
+      solution-name:
+        required: true
+        type: string
+      project-version:
+        required: true
+        type: string
+      prevent-rename-collision:
+        required: false
+        type: string
+        default: 'true'
+    secrets:
+      MYTROUT_SONARQUBE_HOST_URL:
+        required: true
+      MYTROUT_SONARQUBE_ORGANIZATION:
+        required: true
+      MYTROUT_SONARQUBE_API_KEY:
+        required: true
+      MYTROUT_NUGET_API_KEY:
+        required: true
+ 
+jobs:
+  standard-build-job:
+
+    runs-on: ubuntu-latest
+    
+    env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.MYTROUT_SONARQUBE_API_KEY }}
+        SONAR_HOST_URL: 'https://sonarcloud.io/'
+        
+        # These values should be changed for each individual solution.
+        SONAR_PROJECT_NAME: ${{ inputs.sonar-project-name }}
+        WORKING_DIRECTORY: ${{ github.workspace }}${{ inputs.working-directory }}
+        SOLUTION_NAME: ${{ inputs.solution-name }}
+       
+        # This value is to turn on rename step value collisions
+        PIPELINE_PreventCollisionsWithRenamedValueNames: ${{ inputs.prevent-rename-collision }}
+        
+        # This value should change on each deployable version of this solution.
+        PROJECT_VERSION: ${{ inputs.project-version }}
+        
+    steps:
+      - name: Checkout the Source
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET Core SDK 6.0.x and 7.0.x and 8.0.x
+        uses: actions/setup-dotnet@v3.1.0
+        with:
+          dotnet-version: |
+            6.0.x
+            7.0.x
+            8.0.x
+      
+      # "dotnet sonarscanner end" now requires Java 11 to be installed.
+      - name: Setup Java 11 for SonarQube.
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+        if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
+          
+      # https://stackoverflow.com/questions/67597824/sonarscanner-for-net-fails-in-github-actions-net-5
+      - name: Install Sonar global tool
+        run: dotnet tool install --global dotnet-sonarscanner
+        if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
+       
+      - name: Begin Sonar scan
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: dotnet sonarscanner begin /k:${{ env.SONAR_PROJECT_NAME }} /d:sonar.host.url=${{ secrets.MYTROUT_SONARQUBE_HOST_URL }} /o:${{ secrets.MYTROUT_SONARQUBE_ORGANIZATION }} /d:sonar.login=${{ secrets.MYTROUT_SONARQUBE_API_KEY }} /v:${{ env.PROJECT_VERSION }} /d:sonar.cs.opencover.reportsPaths=**/coverage.xml
+        if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
+
+      - name: Build
+        env:
+          PROJECT_FULL_VERSION: ${{ env.PROJECT_VERSION }}.${{ github.run_number }}
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: dotnet build ${{ env.SOLUTION_NAME }} --configuration Release -p:Version=${{ env.PROJECT_VERSION }};AssemblyVersion=${{ env.PROJECT_FULL_VERSION }};FileVersion=${{ env.PROJECT_FULL_VERSION }};SourceRevisionId=${{ env.PROJECT_VERSION }}+${{ env.GITHUB_SHA }}
+
+        # Skip the Unit and Integration Tests when running under Dependabot. 
+        # Due to regression bug with .NET 7.0 -> https://github.com/microsoft/vstest/issues/4014
+        # AltCover provided a solution at https://github.com/SteveGilham/altcover/issues/176
+        # .NET 7.0 should correct the regression bug in 
+      - name: Test
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: |
+          export AltCover=true
+          export CopyLocalLockFileAssemblies=true
+          export AltCoverLocalSource=true
+          export AltCoverAttributeFilter=ExcludeFromCodeCoverage
+          dotnet test --configuration Release --no-build --no-restore --verbosity normal
+        if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
+        
+      - name: End Sonar scan
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: dotnet sonarscanner end /d:sonar.login=${{ secrets.MYTROUT_SONARQUBE_API_KEY }}      
+        if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
+        
+      - name: Upload coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: ${{ env.WORKING_DIRECTORY }}/**/coverage.xml
+          
+      - name: Upload nupkg
+        uses: actions/upload-artifact@v3
+        with:
+          name: nupkg
+          path: ${{ env.WORKING_DIRECTORY }}/src/bin/Release/*.nupkg
+          if-no-files-found: error
+        if: "github.ref == 'refs/heads/main' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
+        
+      - name: Publish the package to nuget.org
+        run: dotnet nuget push "${{ env.WORKING_DIRECTORY }}/src/bin/Release/*.nupkg" --api-key ${{ secrets.MYTROUT_NUGET_API_KEY }} --source "https://api.nuget.org/v3/index.json" --skip-duplicate
+        if: "github.ref == 'refs/heads/main' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"
+
+      - name: Publish the package to GitHub.
+        run: dotnet nuget push "${{ env.WORKING_DIRECTORY }}//src/bin/Release/*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/mytrout/index.json" --skip-duplicate
+        if: "github.ref == 'refs/heads/main' && github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.push.commits.*.author,  'dependabot[bot]')"

--- a/Core/README.md
+++ b/Core/README.md
@@ -16,7 +16,7 @@
 
 MyTrout.Pipelines provides a non-HTTP pipeline similar to the ASP.NET Core request pipeline.
 
-MyTrout.Pipelines targets [.NET 6.0](https://dotnet.microsoft.com/download/dotnet/6.0) and [.NET 7.0](https://dotnet.microsoft.com/download/dotnet/7.0)
+MyTrout.Pipelines targets [.NET 6.0](https://dotnet.microsoft.com/download/dotnet/6.0), [.NET 7.0](https://dotnet.microsoft.com/download/dotnet/7.0), and [.NET 8.0](https://dotnet.microsoft.com/download/dotnet/8.0)
 
 If three steps named M1, M2, and M3 were added to the Pipeline, here is the execution path for the code.
 
@@ -33,10 +33,10 @@ For more details on implementing Pipelines.Hosting, see [Pipelines.Hosting](../H
     Install-Package MyTrout.Pipelines
 
 ## Software dependencies
-    1. Microsoft.Extensions.Configuration.Abstractions 6.0.0
-    2. Microsoft.Extensions.Configuration.Binder 6.0.0
-    3. Microsoft.Extensions.DependencyInjection.Abstractions 6.0.0
-    4. Microsoft.Extensions.Logging.Abstractions 6.0.0
+    1. Microsoft.Extensions.Configuration.Abstractions 8.0.0
+    2. Microsoft.Extensions.Configuration.Binder 8.0.0
+    3. Microsoft.Extensions.DependencyInjection.Abstractions 8.0.0
+    4. Microsoft.Extensions.Logging.Abstractions 8.0.0
 
 All software dependencies listed above use the [MIT License](https://licenses.nuget.org/MIT).
 

--- a/Core/changelog.md
+++ b/Core/changelog.md
@@ -1,5 +1,12 @@
 # MyTrout.Pipelines.Core Change Log
 
+## 4.2.0
+- Upgrade to .NET 8.0.
+- Upgrade libraries to 8.0.0 versions.
+- Correct all new Analyzer issues.
+- Correct missing documentation on StepWithInstance&lt;TStep, TOptions&gt; and StepWithFactory&lt;TStep, TOptions&gt;
+- NOTE TO DEVELOPERS: Obsolete properties in IPipelineContext ad PipelineContext will be removed in v5.0.0 when .NET 6.0 and .NET 7.0 support is removed.
+
 ## 4.1.0
 - Upgrade from preview release of .NET 7.0 to official release.
 

--- a/Core/changelog.md
+++ b/Core/changelog.md
@@ -6,6 +6,8 @@
 - Correct all new Analyzer issues.
 - Correct missing documentation on StepWithInstance&lt;TStep, TOptions&gt; and StepWithFactory&lt;TStep, TOptions&gt;
 - NOTE TO DEVELOPERS: Obsolete properties in IPipelineContext ad PipelineContext will be removed in v5.0.0 when .NET 6.0 and .NET 7.0 support is removed.
+- build template upgraded to build with .NET 6.0, .NET 7.0 and .NET 8.0.
+- build template upgraded to Java 17 for SonarQube.
 
 ## 4.1.0
 - Upgrade from preview release of .NET 7.0 to official release.

--- a/Core/src/Core/StepActivator.cs
+++ b/Core/src/Core/StepActivator.cs
@@ -155,7 +155,7 @@ namespace MyTrout.Pipelines.Core
             foreach (var property in parameter.ParameterType.GetProperties().Where(x => Attribute.IsDefined(x, typeof(FromServicesAttribute), true)))
             {
                 // Setter must exist for this property.
-                var parameterInfo = property.GetSetMethod(true)?.GetParameters().First();
+                var parameterInfo = property.GetSetMethod(true)?.GetParameters()[0];
 
                 if (parameterInfo == null)
                 {
@@ -287,7 +287,7 @@ namespace MyTrout.Pipelines.Core
             foreach (var constructor in pipelineStep.StepType.GetConstructors()
                                                 .OrderByDescending(x => x.GetParameters().Length))
             {
-                if (!constructor.GetParameters().Any(x => x.ParameterType == typeof(IPipelineRequest)))
+                if (!Array.Exists(constructor.GetParameters(), x => x.ParameterType == typeof(IPipelineRequest)))
                 {
                     // Skip this constructor because no next PipelineRequest parameter was found.
                     continue;

--- a/Core/src/MyTrout.Pipelines.csproj
+++ b/Core/src/MyTrout.Pipelines.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Chris Trout</Authors>
     <Copyright>Copyright 2019-2022 Chris Trout. All Rights Reserved.</Copyright>
@@ -37,31 +37,31 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\"/>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
     
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0-preview.23525.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.0.64">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.8.14">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.33.0.40503">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.12.0.78982">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.261">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Core/src/StepWithFactory{TStep,TOptions}.cs
+++ b/Core/src/StepWithFactory{TStep,TOptions}.cs
@@ -29,6 +29,8 @@ namespace MyTrout.Pipelines
     /// <summary>
     /// Provides the ability to configure a Pipeline Step multiple times with different instances and/or functions in the same pipeline.
     /// </summary>
+    /// <typeparam name="TStep">The class which implements the step wrapped by this instance.</typeparam>
+    /// <typeparam name="TOptions">The class which provides configuration for the <typeparamref name="TStep"/>.</typeparam>
     public record StepWithFactory<TStep, TOptions> : StepWithContext, IStepWithFactory
         where TStep : class, IPipelineRequest
         where TOptions : class

--- a/Core/src/StepWithInstance{TStep,TOptions}.cs
+++ b/Core/src/StepWithInstance{TStep,TOptions}.cs
@@ -29,6 +29,8 @@ namespace MyTrout.Pipelines
     /// <summary>
     /// Provides the ability to configure a Pipeline Step multiple times with different instances and/or functions in the same pipeline.
     /// </summary>
+    /// <typeparam name="TStep">The class which implements the step wrapped by this instance.</typeparam>
+    /// <typeparam name="TOptions">The class which provides configuration for the <typeparamref name="TStep"/>.</typeparam>
     public sealed record StepWithInstance<TStep, TOptions> : StepWithContext, IStepWithInstance
         where TStep : class, IPipelineRequest
         where TOptions : class

--- a/Core/src/Steps/LoadValuesFromConfigurationToPipelineContextStep.cs
+++ b/Core/src/Steps/LoadValuesFromConfigurationToPipelineContextStep.cs
@@ -60,7 +60,7 @@ namespace MyTrout.Pipelines.Steps
             {
                 foreach (var itemName in this.Options.ConfigurationNames)
                 {
-                    context.Items.Add(itemName, this.Options.Configuration.GetValue<object>(itemName));
+                    context.Items.Add(itemName, this.Options.Configuration.GetValue<object>(itemName)!);
                 }
 
                 await this.Next.InvokeAsync(context);

--- a/Core/test/MyTrout.Pipelines.Tests.csproj
+++ b/Core/test/MyTrout.Pipelines.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>


### PR DESCRIPTION
- Upgrade to .NET 8.0.
- Upgrade libraries to 8.0.0 versions.
- Correct all new Analyzer issues.
- Correct missing documentation on StepWithInstance&lt;TStep, TOptions&gt; and StepWithFactory&lt;TStep, TOptions&gt;
- NOTE TO DEVELOPERS: Obsolete properties in IPipelineContext ad PipelineContext will be removed in v5.0.0 when .NET 6.0 and .NET 7.0 support is removed.